### PR TITLE
Add Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,131 @@
+name: Publish Docker images
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+        flavor:
+          - name: slim
+            use_bedrock: false
+          - name: full
+            use_bedrock: true
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            USE_BEDROCK=${{ matrix.flavor.use_bedrock }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }}-${{ matrix.flavor.name }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }}-${{ matrix.flavor.name }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}-${{ matrix.flavor.name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - slim
+          - full
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*-${{ matrix.flavor }}
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          flavor=${{ matrix.flavor }}
+          tags=$(jq -cr --arg flavor "$flavor" '.tags | map("-t " + . + "-" + $flavor) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create $tags \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}-${{ matrix.flavor }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM python:3.11.4-slim-buster as builder
+FROM python:3.11.4-slim-buster AS builder
 ARG USE_BEDROCK=false
 COPY requirements.txt /build/
 WORKDIR /build/
+RUN pip install --no-cache-dir -U pip
 RUN if [ "$USE_BEDROCK" = "true" ]; then \
         echo boto3 >> requirements.txt; \
-    fi \
-    && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir -r requirements.txt
+    fi
+RUN pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.11.4-slim-buster as app
+FROM python:3.11.4-slim-buster AS app
 WORKDIR /app/
 COPY *.py /app/
-RUN mkdir /app/app/
 COPY app/*.py /app/app/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/


### PR DESCRIPTION
Add a workflow for Docker image publishing.

Pushing the `vN.N.N` tag will publish the following images:

1. `N.N.N-full`, `latest-full` (includes all libraries, including those only required for certain LLMs, such as boto3)
2. `N.N.N-slim`, `latest-slim` (excludes libraries that are only required for certain LLMs, such as boto3)

Supported platforms:

- linux/amd64
- linux/arm64