### PR TITLE
Fix Bedrock error

### DIFF
--- a/app/litellm_ops.py
+++ b/app/litellm_ops.py
@@ -85,6 +85,13 @@ def messages_within_context_window(
         )
         del messages[0]
 
+    # Remove any assistant messages at the end of the list
+    while messages and messages[-1]["role"] == "assistant":
+        num_context_tokens = litellm.token_counter(
+            model=LITELLM_MODEL_TYPE, messages=messages
+        )
+        del messages[-1]
+
     return messages, num_context_tokens, max_context_tokens
 
 


### PR DESCRIPTION
Fixed the following errors in Amazon Bedrock.

> Your API request included an `assistant` message in the final position, which would pre-fill the `assistant` response. When using tools, pre-filling the `assistant` response is not supported.