### PR TITLE
Support o3-mini

### DIFF
--- a/app/litellm_ops.py
+++ b/app/litellm_ops.py
@@ -124,6 +124,12 @@ def call_litellm_completion(
     stream: bool = False,
     tools: Optional[List] = None,
 ) -> Union[litellm.ModelResponse, litellm.CustomStreamWrapper]:
+    # litellm.drop_params=True should ignore temperature, but it doesn't yet, so remove it here.
+    if LITELLM_MODEL.startswith("o3-mini") or LITELLM_MODEL.startswith("azure/o3-mini"):
+        kwargs = {}
+    else:
+        kwargs = {"temperature": temperature}
+
     return litellm.completion(
         model=LITELLM_MODEL,
         messages=messages,
@@ -137,6 +143,7 @@ def call_litellm_completion(
         stream=stream,
         tools=tools,
         aws_region_name=os.environ.get("AWS_REGION_NAME"),
+        **kwargs,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 slack-bolt>=1.22.0,<2
 slack-sdk>=3.34.0,<4
-litellm>=1.60.0,<2
+litellm>=1.60.5,<2
 pillow>=11.1.0,<12
 requests>=2.32.3,<3


### PR DESCRIPTION
- Added a workaround to remove `temperature` for o3-mini until [BerriAI/litellm#8192](https://github.com/BerriAI/litellm/issues/8192) is resolved.
- Upgraded LiteLLM from 1.60.0 to 1.60.5.