### PR TITLE
Refactor to unify event listeners

### DIFF
--- a/app/bolt_app.py
+++ b/app/bolt_app.py
@@ -1,7 +1,7 @@
 from slack_bolt import Ack, App
 from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
-from app.bolt_listeners import respond_to_app_mention, respond_to_new_message
+from app.bolt_listeners import respond_to_new_message
 from app.bolt_middlewares import before_authorize, set_locale
 from app.env import USE_SLACK_LANGUAGE
 
@@ -21,7 +21,6 @@ def create_bolt_app(
     )
     app.client.retry_handlers.append(RateLimitErrorRetryHandler(max_retry_count=2))
 
-    app.event("app_mention")(ack=just_ack, lazy=[respond_to_app_mention])
     app.event("message")(ack=just_ack, lazy=[respond_to_new_message])
 
     if use_slack_language:

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,6 @@ features:
 oauth_config:
   scopes:
     bot:
-      - app_mentions:read
       - channels:history
       - chat:write
       - chat:write.public
@@ -25,7 +24,6 @@ oauth_config:
 settings:
   event_subscriptions:
     bot_events:
-      - app_mention
       - message.channels
       - message.groups
       - message.im

--- a/tests/bolt_app_test.py
+++ b/tests/bolt_app_test.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from slack_bolt import App
 
 from app.bolt_app import create_bolt_app, just_ack
-from app.bolt_listeners import respond_to_app_mention, respond_to_new_message
+from app.bolt_listeners import respond_to_new_message
 from app.bolt_middlewares import set_locale
 
 
@@ -40,12 +40,8 @@ def test_create_bolt_app_with_locale():
 
         assert mock_rate_limit_handler in mock_app_instance.client.retry_handlers
 
-        mock_app_instance.event.assert_any_call("app_mention")
         mock_app_instance.event.assert_any_call("message")
 
-        mock_app_instance.event("app_mention").assert_any_call(
-            ack=mock_just_ack, lazy=[respond_to_app_mention]
-        )
         mock_app_instance.event("message").assert_any_call(
             ack=mock_just_ack, lazy=[respond_to_new_message]
         )


### PR DESCRIPTION
The `app_mention` event listener has been removed, and all messages are now handled via the `message` event listener.

If you've already installed the Slack app, please remove the following from your configuration:

- The OAuth scope `app_mentions:read`
- The subscribed event `app_mention`

You can refer to `manifest.yml` for the updated configuration.