### PR TITLE
Add prompt caching feature for Anthropic models

### DIFF
--- a/app/env.py
+++ b/app/env.py
@@ -66,6 +66,10 @@ IMAGE_FILE_ACCESS_ENABLED = (
 
 PDF_FILE_ACCESS_ENABLED = os.environ.get("PDF_FILE_ACCESS_ENABLED", "false") == "true"
 
+ANTHROPIC_PROMPT_CACHING_ENABLED = (
+    os.environ.get("ANTHROPIC_PROMPT_CACHING_ENABLED", "false") == "true"
+)
+
 # Redaction patterns
 #
 REDACT_EMAIL_PATTERN = os.environ.get(


### PR DESCRIPTION
This change introduces prompt caching support for Anthropic models by setting cache breakpoints on recent user messages when the context length exceeds a threshold, 1,024 tokens.

Caching is conditionally enabled via the `ANTHROPIC_PROMPT_CACHING_ENABLED` environment variable.

References:
- Anthropic prompt caching: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
- LiteLLM support: https://docs.litellm.ai/docs/completion/prompt_caching