### PR TITLE
feat: Filter logs to include only user messages

### DIFF
--- a/examples/callback_handler.py
+++ b/examples/callback_handler.py
@@ -7,27 +7,30 @@ from litellm.integrations.custom_logger import CustomLogger
 
 class CallbackHandler(CustomLogger):
     def log_pre_api_call(self, model, messages, kwargs):
-        # Omit image data and output request log
+        if not messages or messages[-1].get("role") != "user":
+            return
+
+        messages = [messages[-1]]
+        content = messages[0].get("content")
+        if isinstance(content, list):
+            for c in content:
+                if c["type"] == "image_url":
+                    c["image_url"]["url"] = "(omitted)"
+                elif c["type"] == "file":
+                    c["file"]["file_data"] = "(omitted)"
+
         keys_to_keep = [
             "model",
-            "messages",
             "max_tokens",
             "temperature",
             "user",
             "stream",
-            "tools",
         ]
         model_call_dict = {
             k: copy.deepcopy(v) for k, v in kwargs.items() if k in keys_to_keep
         }
-        if "messages" in model_call_dict:
-            for message in model_call_dict["messages"]:
-                if "content" in message and isinstance(message["content"], list):
-                    for content in message["content"]:
-                        if content["type"] == "image_url":
-                            content["image_url"]["url"] = "(omitted)"
-                        elif content["type"] == "file":
-                            content["file"]["file_data"] = "(omitted)"
+        model_call_dict["messages"] = messages
+
         logger = logging.getLogger("Collmbo")
         logger.info(f"model call details: {json.dumps(model_call_dict)}")
 


### PR DESCRIPTION
## Summary
- Filter logs to show only user messages in the callback handler example
- Remove system messages and unnecessary fields from logs

## Changes
- Log only user messages (exclude system role)
- Record only the last message
- Remove tools field from output

🤖 Generated with [Claude Code](https://claude.ai/code)