### PR TITLE
fix: prepend PDF files to content for Bedrock Converse API compatibility

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -430,8 +430,10 @@ def convert_replies_to_messages(
             )
 
             # Count and add PDFs
+            # Note: Prepend PDFs to avoid Bedrock Converse API error
+            # (cache control cannot immediately follow document type)
             used_pdf_slots += len(pdf_file_items)
-            content += pdf_file_items
+            content = pdf_file_items + content
 
         messages.append(build_user_message(content))
 


### PR DESCRIPTION
## Summary
- Changed PDF file insertion from append to prepend in content array
- This avoids an error in Amazon Bedrock's Converse API where cache control cannot immediately follow document type
- The new order is: document (PDF) → text → cache control, which is compatible with Bedrock

🤖 Generated with [Claude Code](https://claude.ai/code)