### PR TITLE
Use ARM64 native runners for Docker builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     permissions:
       packages: write
@@ -23,6 +23,11 @@ jobs:
         flavor:
           - slim
           - full
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Prepare
         run: |
@@ -37,9 +42,6 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
## Summary
- Configure platform-specific runners in GitHub Actions workflow
- Use native ARM64 runners (`ubuntu-24.04-arm`) for ARM64 Docker image builds
- Remove QEMU emulation setup as it's no longer needed for native ARM64 builds

## Background
GitHub recently made ARM64 hosted runners generally available for public repositories ([announcement](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)).

Previously, ARM64 images were built on x86_64 runners using QEMU emulation, which was significantly slower. With native ARM64 runners, we can build ARM64 images directly on ARM hardware, resulting in faster build times.

## Changes
- Modified `.github/workflows/publish.yml`:
  - Changed `runs-on` to use dynamic runner selection via `${{ matrix.runner }}`
  - Added `matrix.include` to specify appropriate runners for each platform:
    - `ubuntu-24.04` for linux/amd64
    - `ubuntu-24.04-arm` for linux/arm64
  - Removed QEMU setup step as it's no longer needed

🤖 Generated with [Claude Code](https://claude.ai/code)