### PR TITLE
Add websockets dependency for LiteLLM SDK workaround

### DIFF
--- a/slim-requirements.txt
+++ b/slim-requirements.txt
@@ -15,3 +15,4 @@ email-validator==2.2.0
 fastapi==0.116.1
 fastapi-sso==0.18.0
 orjson==3.11.1
+websockets==15.0.1


### PR DESCRIPTION
## Summary
Added `websockets==15.0.1` to `slim-requirements.txt` as part of the workaround for LiteLLM SDK dependency bug.

## Background
The LiteLLM SDK has a bug where it incorrectly requires `litellm[proxy]` dependencies even when only the SDK functionality is needed. This causes import errors unless the proxy dependencies are installed.

Related issue: https://github.com/BerriAI/litellm/issues/13081

## Changes
- Added `websockets==15.0.1` to the workaround dependency list in `slim-requirements.txt`
- This joins other workaround packages already added (apscheduler, backoff, cryptography, email-validator, fastapi, fastapi-sso, orjson)

## Note
These dependencies are not actually used by our application but are required to avoid import errors due to the LiteLLM SDK's incorrect dependency handling.

🤖 Generated with [Claude Code](https://claude.ai/code)