### PR TITLE
Move renovate.json to .github/ and add dependencies label

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
## Summary
- Moved renovate.json from root to .github/ directory for better organization
- Added "dependencies" label configuration to automatically label all Renovate PRs

🤖 Generated with [Claude Code](https://claude.ai/code)