### PR TITLE
Add openai==1.99.9 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ fastapi==0.116.1
 fastapi-sso==0.18.0
 orjson==3.11.2
 websockets==15.0.1
+
+# workaround for https://github.com/BerriAI/litellm/issues/13710
+openai==1.99.9


### PR DESCRIPTION
## Summary
- Pin openai to version 1.99.9 as a workaround for litellm issue #13710

## Details
This change adds `openai==1.99.9` to requirements.txt to address compatibility issues with litellm.
See: https://github.com/BerriAI/litellm/issues/13710

🤖 Generated with [Claude Code](https://claude.ai/code)