### PR TITLE
Add Rust toolchain to Docker builder for fastuuid dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.13.7-slim-bookworm AS builder
 WORKDIR /build/
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cargo rustc \
+ && rm -rf /var/lib/apt/lists/*
 COPY uv-requirements.txt /build/
 RUN pip install --no-cache-dir -r uv-requirements.txt
 COPY requirements.txt /build/


### PR DESCRIPTION
## Summary
Add Rust compiler and cargo to the Docker builder stage to support building fastuuid package

## Details
LiteLLM has introduced a dependency on fastuuid, which is a Rust-based Python package. To build this package during Docker image creation, we need the Rust toolchain (rustc and cargo) available in the builder stage.

### Changes
- Install `cargo` and `rustc` in the builder stage
- Use `--no-install-recommends` to minimize package size
- Clean up apt cache after installation to reduce image size

🤖 Generated with [Claude Code](https://claude.ai/code)