### PR TITLE
Pin LiteLLM to 1.76.0 to avoid fastuuid dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.13.7-slim-bookworm AS builder
 WORKDIR /build/
-RUN apt-get update \
- && apt-get install -y --no-install-recommends cargo rustc \
- && rm -rf /var/lib/apt/lists/*
 COPY uv-requirements.txt /build/
 RUN pip install --no-cache-dir -r uv-requirements.txt
 COPY requirements.txt /build/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
 slack-bolt==1.24.0
 slack-sdk==3.36.0
-litellm==1.76.3
 pillow==11.3.0
 requests==2.32.5
 mcp==1.13.1
 strands-agents==1.7.1
 strands-agents-tools==0.2.6
+
+# avoid fastuuid dependency
+# see: https://github.com/BerriAI/litellm/issues/14145
+litellm==1.76.0
 
 # workaround for https://github.com/BerriAI/litellm/issues/13081
 apscheduler


### PR DESCRIPTION
## Summary
Pin LiteLLM to version 1.76.0 to avoid the fastuuid dependency introduced in later versions

## Details
LiteLLM versions after 1.76.0 introduce a dependency on fastuuid, which is a Rust-based package that requires the Rust toolchain (cargo and rustc) to build. This adds complexity to our Docker builds.

By pinning to 1.76.0, we can avoid this dependency until the issue is resolved upstream.

### Changes
- Pin `litellm` to version 1.76.0 in requirements.txt
- Add comment explaining the reason for pinning
- Remove Rust toolchain additions from Dockerfile (no longer needed)

### Related Issue
- https://github.com/BerriAI/litellm/issues/14145

🤖 Generated with [Claude Code](https://claude.ai/code)