### PR TITLE
refactor: simplify AgentCore configuration structure

### DIFF
--- a/app/mcp/agentcore_logic.py
+++ b/app/mcp/agentcore_logic.py
@@ -2,8 +2,6 @@
 Logic functions for AgentCore Identity integration.
 """
 
-from typing import Optional
-
 
 def create_agentcore_user_id(slack_user_id: str, random_suffix: str) -> str:
     """
@@ -17,25 +15,3 @@ def create_agentcore_user_id(slack_user_id: str, random_suffix: str) -> str:
         str: User ID for AgentCore in format: {slack_user_id}_{random_suffix}.
     """
     return f"{slack_user_id}_{random_suffix}"
-
-
-def normalize_agentcore_config(server: dict) -> Optional[dict]:
-    """
-    Normalize AgentCore configuration from server config.
-
-    Args:
-        server (dict): Server configuration from mcp.yml.
-
-    Returns:
-        Optional[dict]: AgentCore config if valid, None otherwise.
-    """
-    if not server.get("agentcore_identity"):
-        return None
-    agentcore = server["agentcore_identity"]
-    if not agentcore.get("region") or not agentcore.get("provider_name"):
-        return None
-    return {
-        "region": agentcore["region"],
-        "provider_name": agentcore["provider_name"],
-        "scopes": server.get("scopes", []),
-    }

--- a/app/mcp/config_service.py
+++ b/app/mcp/config_service.py
@@ -110,6 +110,17 @@ def get_workload_name() -> str:
     return config.get("workload_name", DEFAULT_WORKLOAD_NAME)
 
 
+def get_agentcore_region() -> str:
+    """
+    Get AgentCore region from global configuration.
+
+    Returns:
+        str: AgentCore region for OAuth MCP servers.
+    """
+    config = get_mcp_config()
+    return config.get("agentcore_region", "us-west-2")
+
+
 def get_auth_session_duration_minutes() -> int:
     """
     Get auth session duration in minutes from configuration.

--- a/app/mcp/oauth_control_service.py
+++ b/app/mcp/oauth_control_service.py
@@ -9,13 +9,13 @@ from typing import Callable
 
 from slack_sdk import WebClient
 
-from app.mcp.agentcore_logic import normalize_agentcore_config
 from app.mcp.agentcore_service import (
     cancel_oauth_polling,
     get_oauth_polling_status,
     initiate_oauth_flow_with_callback,
 )
 from app.mcp.config_service import (
+    get_agentcore_region,
     get_auth_session_duration_minutes,
     get_oauth_server,
     get_workload_name,
@@ -197,18 +197,18 @@ def enable_user_oauth_session(
         on_update=on_update,
     )
 
-    agentcore_config = normalize_agentcore_config(server)
-    if not agentcore_config:
-        raise ValueError(f"Invalid AgentCore configuration for server: {server_name}")
+    provider_name = server.get("agentcore_provider")
+    if not provider_name:
+        raise ValueError(f"Invalid AgentCore provider for server: {server_name}")
 
     async def run_oauth_flow():
         await initiate_oauth_flow_with_callback(
-            region=agentcore_config["region"],
+            region=get_agentcore_region(),
             workload_name=get_workload_name(),
             user_id=user_id,
             server_name=server_name,
-            provider_name=agentcore_config["provider_name"],
-            scopes=agentcore_config.get("scopes", []),
+            provider_name=provider_name,
+            scopes=server.get("scopes", []),
             on_auth_url_callback=on_auth_url_callback,
             on_token_callback=on_token_callback,
             on_timeout_callback=on_timeout_callback,

--- a/config/mcp.yml
+++ b/config/mcp.yml
@@ -1,5 +1,6 @@
 workload_name: Collmbo
 auth_session_duration_minutes: 30
+agentcore_region: us-west-2
 servers:
   - name: AWS Knowledge
     url: https://knowledge-mcp.global.api.aws
@@ -13,6 +14,4 @@ servers:
 #     - repo
 #     - read:packages
 #     - read:org
-#   agentcore_identity:
-#     region: us-west-2
-#     provider_name: github
+#   agentcore_provider: github

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -39,6 +39,7 @@ AWS_SECRET_ACCESS_KEY=...
 $ cat config/mcp.yml
 workload_name: Collmbo
 auth_session_duration_minutes: 30
+agentcore_region: us-west-2
 servers:
   - name: AWS Knowledge
     url: https://knowledge-mcp.global.api.aws
@@ -50,9 +51,7 @@ servers:
       - repo
       - read:packages
       - read:org
-    agentcore_identity:
-      region: us-west-2
-      provider_name: github
+    agentcore_provider: github
 
 $ cat env
 SLACK_APP_TOKEN=xapp-1-...

--- a/tests/home_tab_logic_test.py
+++ b/tests/home_tab_logic_test.py
@@ -316,10 +316,7 @@ def test_build_home_tab_blocks(mcp_servers, expected_blocks):
                         "name": "GitHubServer",
                         "url": "http://test",
                         "auth_type": "user_federation",
-                        "agentcore_identity": {
-                            "region": "us-east-1",
-                            "provider": "github",
-                        },
+                        "agentcore_provider": "github",
                     }
                 ]
             },
@@ -353,10 +350,7 @@ def test_build_home_tab_blocks(mcp_servers, expected_blocks):
                         "name": "GitHubServer",
                         "url": "http://test",
                         "auth_type": "user_federation",
-                        "agentcore_identity": {
-                            "region": "us-east-1",
-                            "provider": "github",
-                        },
+                        "agentcore_provider": "github",
                     }
                 ]
             },

--- a/tests/mcp/agentcore_logic_test.py
+++ b/tests/mcp/agentcore_logic_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from app.mcp.agentcore_logic import (
     create_agentcore_user_id,
-    normalize_agentcore_config,
 )
 
 
@@ -35,39 +34,5 @@ from app.mcp.agentcore_logic import (
 )
 def test_create_agentcore_user_id(slack_user_id, session_id, expected):
     result = create_agentcore_user_id(slack_user_id, session_id)
-
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "server, expected",
-    [
-        (
-            {
-                "agentcore_identity": {
-                    "region": "us-east-1",
-                    "provider_name": "github",
-                },
-                "scopes": ["read", "write"],
-            },
-            {
-                "region": "us-east-1",
-                "provider_name": "github",
-                "scopes": ["read", "write"],
-            },
-        ),
-        (
-            {"agentcore_identity": {"region": "us-west-2", "provider_name": "google"}},
-            {"region": "us-west-2", "provider_name": "google", "scopes": []},
-        ),
-        ({}, None),
-        ({"agentcore_identity": {}}, None),
-        ({"agentcore_identity": {"region": "us-east-1"}}, None),
-        ({"agentcore_identity": {"provider_name": "github"}}, None),
-        ({"other_config": "value"}, None),
-    ],
-)
-def test_normalize_agentcore_config(server, expected):
-    result = normalize_agentcore_config(server)
 
     assert result == expected

--- a/tests/mcp/oauth_logic_test.py
+++ b/tests/mcp/oauth_logic_test.py
@@ -25,10 +25,7 @@ from app.mcp.oauth_tools_logic import is_session_not_expired
                         "name": "Server 2",
                         "url": "https://server2.example.com",
                         "auth_type": "user_federation",
-                        "agentcore_identity": {
-                            "region": "us-east-1",
-                            "provider": "aws",
-                        },
+                        "agentcore_provider": "aws",
                     },
                 ]
             },
@@ -37,7 +34,7 @@ from app.mcp.oauth_tools_logic import is_session_not_expired
                     "name": "Server 2",
                     "url": "https://server2.example.com",
                     "auth_type": "user_federation",
-                    "agentcore_identity": {"region": "us-east-1", "provider": "aws"},
+                    "agentcore_provider": "aws",
                 }
             ],
         ),


### PR DESCRIPTION
## Summary
- Simplified AgentCore Identity configuration by removing unnecessary nesting
- Added global `agentcore_region` setting for all OAuth MCP servers
- Replaced `agentcore_identity.provider_name` with flat `agentcore_provider`

## Changes
- **Global region setting**: All OAuth MCP servers now use a single `agentcore_region` configuration
- **Flattened structure**: `agentcore_identity` object replaced with simple `agentcore_provider` string
- **Code cleanup**: Removed `normalize_agentcore_config()` function as it's no longer needed
- **Direct access**: OAuth control service now directly accesses configuration values

## Configuration Example
```yaml
# Before
servers:
  - name: GitHub
    agentcore_identity:
      region: us-west-2
      provider_name: github

# After  
agentcore_region: us-west-2  # Global setting
servers:
  - name: GitHub
    agentcore_provider: github  # Simple string value
```

🤖 Generated with [Claude Code](https://claude.ai/code)