### PR TITLE
Migrate organization references from iwamot to enechange

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) Slack Technologies, LLC
-Copyright (c) 2024 Takashi Iwamoto
+Copyright (c) 2024 ENECHANGE Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Collmbo
 
-[![CI](https://github.com/iwamot/collmbo/actions/workflows/ci.yml/badge.svg)](https://github.com/iwamot/collmbo/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/iwamot/collmbo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/iwamot/collmbo)
+[![CI](https://github.com/enechange/collmbo/actions/workflows/ci.yml/badge.svg)](https://github.com/enechange/collmbo/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/enechange/collmbo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/enechange/collmbo)
 
 ![Collmbo icon](https://github.com/user-attachments/assets/b13da1c7-5d2f-4ad3-8c5b-9ef4e500deb8)
 
@@ -36,12 +36,12 @@ OPENAI_API_KEY=sk-...
 Start the bot using Docker:
 
 ```sh
-docker run -it --env-file .env ghcr.io/iwamot/collmbo:latest
+docker run -it --env-file .env ghcr.io/enechange/collmbo:latest
 ```
 
 > [!NOTE]
 >
-> For versioned releases, you can specify a tag like `x.x.x`. For more details, please check the [list of available tags](https://github.com/iwamot/collmbo/pkgs/container/collmbo/versions?filters%5Bversion_type%5D=tagged).
+> For versioned releases, you can specify a tag like `x.x.x`. For more details, please check the [list of available tags](https://github.com/enechange/collmbo/pkgs/container/collmbo/versions?filters%5Bversion_type%5D=tagged).
 
 ### 4. Say Hello!
 

--- a/docs/features/custom-callbacks.md
+++ b/docs/features/custom-callbacks.md
@@ -19,7 +19,7 @@ OPENAI_API_KEY=sk-...
 LITELLM_MODEL=gpt-4o
 LITELLM_CALLBACK_MODULE_NAME=examples.callback_handler
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
 ```
 
 > ![Custom callbacks example](https://github.com/user-attachments/assets/38a83ac9-1429-46ad-bd6c-95e1d6aac247)

--- a/docs/features/image-input.md
+++ b/docs/features/image-input.md
@@ -15,7 +15,7 @@ OPENAI_API_KEY=sk-...
 LITELLM_MODEL=gpt-4o
 IMAGE_FILE_ACCESS_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
 ```
 
 > ![Image input example](https://github.com/user-attachments/assets/41e11441-230e-41db-8cae-efe5fd9dd426)

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -63,7 +63,7 @@ LITELLM_MODEL=gpt-4o
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 
-$ docker run -it --env-file ./env -v ./config:/app/config ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env -v ./config:/app/config ghcr.io/enechange/collmbo:latest
 ```
 
 `workload_name` will be used as a name for [AgentCore Identity workload](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/creating-agent-identities.html).

--- a/docs/features/pdf-input.md
+++ b/docs/features/pdf-input.md
@@ -15,7 +15,7 @@ OPENAI_API_KEY=sk-...
 LITELLM_MODEL=bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
 PDF_FILE_ACCESS_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
 ```
 
 > ![PDF input example](https://github.com/user-attachments/assets/181a5400-3d6c-4daf-aa64-7d7cdd4cfaee)

--- a/docs/features/prompt-caching.md
+++ b/docs/features/prompt-caching.md
@@ -12,7 +12,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 LITELLM_MODEL=claude-3-7-sonnet-20250219
 PROMPT_CACHING_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
 ```
 
 When enabled, cache breakpoints will automatically be added to **the two most recent user messages** when the total context size is 1,024 tokens or more. This may help reduce API costs.

--- a/docs/features/redaction.md
+++ b/docs/features/redaction.md
@@ -20,7 +20,7 @@ REDACT_USER_DEFINED_PATTERN=\bsensitive string\b
 # Here, logging is enabled to check the effect of redaction
 LITELLM_CALLBACK_MODULE_NAME=examples.callback_handler
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
 ```
 
 Sensitive strings in the message will be masked before being sent to the model.

--- a/docs/features/slack-friendly-formatting.md
+++ b/docs/features/slack-friendly-formatting.md
@@ -12,7 +12,7 @@ OPENAI_API_KEY=sk-...
 LITELLM_MODEL=gpt-4o
 TRANSLATE_MARKDOWN=true
 
-$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
 ```
 
 > ![Slack formatting example](https://github.com/user-attachments/assets/6d73ed53-2849-4370-acb3-62694c05f86f)

--- a/docs/features/tools-function-calling.md
+++ b/docs/features/tools-function-calling.md
@@ -19,7 +19,7 @@ OPENAI_API_KEY=sk-...
 LITELLM_MODEL=gpt-4o
 LITELLM_TOOLS_MODULE_NAME=examples.tools
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
 ```
 
 > ![Tools example](https://github.com/user-attachments/assets/d48a44fd-56fa-43c7-a0de-567ba03088b5)


### PR DESCRIPTION
## Summary
- Update copyright in LICENSE from Takashi Iwamoto to ENECHANGE Ltd.
- Update GitHub repository URLs and badges in README.md from iwamot/collmbo to enechange/collmbo
- Update Docker image references in all feature documentation from ghcr.io/iwamot/collmbo to ghcr.io/enechange/collmbo

🤖 Generated with [Claude Code](https://claude.ai/code)