### PR TITLE
Add DCO requirements to contribution guide

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Collmbo
+
+We welcome contributions! Please follow these guidelines when submitting pull requests.
+
+## Before Submitting a PR
+
+### 1. Run Validation
+
+Ensure code quality by running:
+
+```bash
+./validate.sh
+```
+
+This runs formatting, linting, type checking, and tests.
+
+### 2. Sign Commits with DCO
+
+All commits must be signed with DCO. Use `git commit -s` to sign your commits.
+
+- Use your real name (no pseudonyms)
+- All commits in a PR must be signed
+- If the DCO check fails, see the check details page for instructions on fixing unsigned commits
+
+For more about DCO: https://developercertificate.org/

--- a/README.md
+++ b/README.md
@@ -121,15 +121,9 @@ Collmbo runs with default settings, but you can customize its behavior by [setti
 
 ## Contributing
 
-Contributions are welcome! Feel free to open an issue or submit a pull request.
+Contributions are welcome! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
-Before opening a PR, please run:
-
-```sh
-./validate.sh
-```
-
-This helps maintain code quality.
+All commits must be signed with DCO (`git commit -s`).
 
 ## Related Projects
 


### PR DESCRIPTION
## Summary

This PR adds Developer Certificate of Origin (DCO) requirements for all contributions to the Collmbo project.

## Changes

- Create `CONTRIBUTING.md` with clear DCO signing instructions
- Update `README.md` to reference the contribution guide
- Require `git commit -s` for all commits
- Include validation script (`./validate.sh`) requirement before PR submission

## Notes

- All future contributions will require DCO signature
- Contributors must use their real names (no pseudonyms)
- The DCO app has been installed on the repository to enforce these requirements