### PR TITLE
fix: ensure MCP tool parameters have required OpenAI API schema fields

### DIFF
--- a/app/mcp/tools_logic.py
+++ b/app/mcp/tools_logic.py
@@ -61,6 +61,12 @@ def transform_mcp_spec_to_classic_tool(
     """
     parameters = deepcopy(mcp_spec["inputSchema"]["json"])
 
+    # Ensure parameters has required fields for OpenAI API
+    if "type" not in parameters:
+        parameters["type"] = "object"
+    if "properties" not in parameters:
+        parameters["properties"] = {}
+
     # Remove invalid "format" property for Gemini models
     if model.startswith("gemini/"):
         for prop in parameters.get("properties", {}).values():


### PR DESCRIPTION
## Summary

- Fixed BadRequestError when using MCP tools with no parameters (e.g., AWS Knowledge MCP Server's `list_regions`)
- Added validation to ensure tool parameters always include `type: "object"` and `properties: {}` fields required by OpenAI API
- Empty `inputSchema.json` from parameter-less MCP tools now properly transformed to valid OpenAI function schema

## Changes

Modified `app/mcp/tools_logic.py`:
- Added checks in `transform_mcp_spec_to_classic_tool()` to ensure `parameters` object has required `type` and `properties` fields
- Prevents "object schema missing properties" errors from OpenAI API when MCP tools have no input parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)