### PR TITLE
test: improve tools_logic coverage to 100%

### DIFF
--- a/tests/mcp/tools_logic_test.py
+++ b/tests/mcp/tools_logic_test.py
@@ -166,6 +166,45 @@ def test_is_mcp_tool_name(name, expected):
                 },
             },
         ),
+        (
+            {
+                "name": "test_tool",
+                "description": "Test tool without type",
+                "inputSchema": {"json": {"properties": {"param": {"type": "string"}}}},
+            },
+            "none",
+            0,
+            "gpt-4",
+            {
+                "type": "function",
+                "function": {
+                    "name": "n-0-test_tool",
+                    "description": "Test tool without type",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"param": {"type": "string"}},
+                    },
+                },
+            },
+        ),
+        (
+            {
+                "name": "test_tool",
+                "description": "Test tool without properties",
+                "inputSchema": {"json": {"type": "object"}},
+            },
+            "none",
+            0,
+            "gpt-4",
+            {
+                "type": "function",
+                "function": {
+                    "name": "n-0-test_tool",
+                    "description": "Test tool without properties",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ),
     ],
 )
 def test_transform_mcp_spec_to_classic_tool(


### PR DESCRIPTION
## Summary
- Add test cases for missing `type` and `properties` fields in MCP tool specs
- Improves `app/mcp/tools_logic.py` coverage from 88% to 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)