### PR TITLE
refactor: replace requests with httpx

### DIFF
--- a/app/slack_file_service.py
+++ b/app/slack_file_service.py
@@ -2,7 +2,7 @@
 This module provides a function to download files from Slack.
 """
 
-import requests
+import httpx
 from slack_sdk.errors import SlackApiError
 
 
@@ -23,9 +23,7 @@ def get_slack_file_content(
     Returns:
         - bytes: The content of the Slack file.
     """
-    response = requests.get(
-        url, headers={"Authorization": f"Bearer {token}"}, timeout=10
-    )
+    response = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
     if response.status_code != 200:
         raise SlackApiError(
             f"Request to {url} failed with status code {response.status_code}", response

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,3 @@ pytest==8.4.2
 pytest-cov==7.0.0
 types-PyYAML==6.0.12.20250915
 types-pytz==2025.2.0.20250809
-types-requests==2.32.4.20250913

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ slack-bolt==1.26.0
 slack-sdk==3.37.0
 litellm==1.78.0
 pillow==11.3.0
-requests==2.32.5
+httpx==0.28.1
 bedrock-agentcore==0.1.7
 mcp==1.17.0
 pytz==2025.2


### PR DESCRIPTION
## Summary

Replace the requests library with httpx for HTTP operations. This modernizes the HTTP client and provides better async support for future enhancements.

## Changes

- Replace `requests.get` with `httpx.get` in `slack_file_service.py`
- Update `requirements.txt`: `requests==2.32.5` → `httpx==0.28.1`
- Remove `types-requests` from `dev-requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)