### PR TITLE
chore: upgrade Python to 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up Python 3.13
+      - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Run validation script
         run: bash validate.sh ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.13.7-slim-trixie AS builder
+FROM python:3.14.0-slim-trixie AS builder
 WORKDIR /build/
 COPY uv-requirements.txt /build/
 RUN pip install --no-cache-dir -r uv-requirements.txt
 COPY requirements.txt /build/
 RUN uv pip install --system --no-cache -r requirements.txt
 
-FROM python:3.13.7-slim-trixie AS app
+FROM python:3.14.0-slim-trixie AS app
 WORKDIR /app/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/


### PR DESCRIPTION
## Summary
- Upgraded Python version from 3.13 to 3.14 in CI workflow
- Updated Dockerfile base images to python:3.14.0-slim-trixie
- Ensures compatibility with the latest Python stable release

This change updates the Python runtime environment across both development (CI) and production (Docker) environments to use Python 3.14, which was recently released as a stable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)