### PR TITLE
fix: handle 302 redirects when downloading Slack files

### DIFF
--- a/app/slack_file_service.py
+++ b/app/slack_file_service.py
@@ -23,7 +23,12 @@ def get_slack_file_content(
     Returns:
         - bytes: The content of the Slack file.
     """
-    response = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
+    response = httpx.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+        follow_redirects=True,
+    )
     if response.status_code != 200:
         raise SlackApiError(
             f"Request to {url} failed with status code {response.status_code}", response


### PR DESCRIPTION
## Summary

Fixed an issue where 302 redirects during Slack PDF file downloads were treated as errors. Added `follow_redirects=True` to `httpx.get()` to automatically follow redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)