### PR TITLE
chore: increase GitHub Actions timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: Run Linting, Type Check, and Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       packages: write
     strategy:
@@ -76,7 +76,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       packages: write
     needs:


### PR DESCRIPTION
## Summary
- Increased timeout for CI workflow from 10 to 20 minutes
- Increased timeout for publish workflow (build and merge jobs) from 10 to 20 minutes
- Added 10-minute timeout for dependency-review workflow

The grpcio dependency build has been taking longer, causing CI jobs to timeout at the previous 10-minute limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)