### PR TITLE
chore: downgrade Python from 3.14 to 3.13.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Run validation script
         run: bash validate.sh ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.14.0-slim-trixie AS builder
+FROM python:3.13.9-slim-trixie AS builder
 WORKDIR /build/
 COPY uv-requirements.txt /build/
 RUN pip install --no-cache-dir -r uv-requirements.txt
 COPY requirements.txt /build/
 RUN uv pip install --system --no-cache -r requirements.txt
 
-FROM python:3.14.0-slim-trixie AS app
+FROM python:3.13.9-slim-trixie AS app
 WORKDIR /app/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/


### PR DESCRIPTION
## Summary
- Downgraded Python from 3.14.0 to 3.13.9 in Dockerfile
- Updated CI workflow to use Python 3.13

LiteLLM now restricts grpcio to <1.68.0, which doesn't provide wheels for Python 3.14. This caused slow builds from source in CI. Python 3.13.9 has pre-built wheels available, significantly reducing build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)