### PR TITLE
chore: add zizmor security check and fix template injection warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,9 +63,11 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${STEPS_BUILD_OUTPUTS_DIGEST}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -114,8 +116,10 @@ jobs:
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create $tags \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf '${REGISTRY_IMAGE}@sha256:%s ' *)
 
       - name: Inspect image
+        env:
+          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${REGISTRY_IMAGE}:${STEPS_META_OUTPUTS_VERSION}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pytest==9.0.1
 pytest-cov==7.0.0
 types-PyYAML==6.0.12.20250915
 types-pytz==2025.2.0.20251108
+zizmor==1.17.0

--- a/validate.sh
+++ b/validate.sh
@@ -17,3 +17,10 @@ if [[ "$1" == "ci" ]]; then
 else
   pytest --cov=main --cov=app --cov-branch --cov-report=term
 fi
+
+# Check GitHub Actions workflows for security issues
+if [[ "$1" == "ci" ]]; then
+  zizmor .github/workflows/
+else
+  zizmor --fix .github/workflows/
+fi


### PR DESCRIPTION
## Summary
- Added zizmor v1.17.0 to dev-requirements.txt
- Integrated zizmor security check into validate.sh
- Fixed template injection warnings in publish.yml

zizmor checks GitHub Actions workflows for security vulnerabilities like template injection, credential leaks, and permission issues. It runs automatically in validate.sh with safe auto-fixes enabled for local development.

All template injection warnings have been resolved by converting template expressions to environment variables before shell execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)