### PR TITLE
fix: use double quotes for variable expansion in printf

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create $tags \
-            $(printf '${REGISTRY_IMAGE}@sha256:%s ' *)
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
       - name: Inspect image
         env:


### PR DESCRIPTION
## Summary
Fixed a bug in publish.yml where `REGISTRY_IMAGE` variable was not being expanded due to single quotes in printf command.

## Problem
The zizmor auto-fix changed the printf command to use single quotes:
```bash
$(printf '${REGISTRY_IMAGE}@sha256:%s ' *)
```

Single quotes prevent shell variable expansion, causing the literal string `${REGISTRY_IMAGE}` to be passed to the Docker command instead of the actual registry URL `ghcr.io/enechange/collmbo`.

## Solution
Changed to double quotes to allow variable expansion:
```bash
$(printf "${REGISTRY_IMAGE}@sha256:%s " *)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)