### PR TITLE
feat: run Trivy scan after Docker image publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,3 +123,9 @@ jobs:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${STEPS_META_OUTPUTS_VERSION}"
+
+  trivy:
+    needs: merge
+    uses: ./.github/workflows/trivy.yml
+    permissions:
+      security-events: write

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,6 +3,7 @@ name: Trivy security scan
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to Trivy workflow
- Call Trivy scan from publish workflow after merge job succeeds
- Ensures Security tab is updated immediately after new image is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)