### PR TITLE
fix: use array for digest expansion in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,8 +115,8 @@ jobs:
         working-directory: /tmp/digests
         run: |
           readarray -t tag_array < <(jq -cr '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          docker buildx imagetools create "${tag_array[@]}" \
-            "$(printf "${REGISTRY_IMAGE}@sha256:%s " *)"
+          readarray -t digest_array < <(printf "${REGISTRY_IMAGE}@sha256:%s\n" *)
+          docker buildx imagetools create "${tag_array[@]}" "${digest_array[@]}"
 
       - name: Inspect image
         env:


### PR DESCRIPTION
## Summary
- Use readarray to store digest list in array
- Prevents word splitting issues with quoted expansion
- Resolves SC2046 shellcheck warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)