### PR TITLE
[DEBUG] Add logging for digest expansion issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,17 @@ jobs:
         working-directory: /tmp/digests
         run: |
           readarray -t tag_array < <(jq -cr '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          echo "Tag array elements:"
+          printf '%s\n' "${tag_array[@]}"
+
           readarray -t digest_array < <(printf "${REGISTRY_IMAGE}@sha256:%s\n" *)
+          echo "Digest array elements:"
+          printf '%s\n' "${digest_array[@]}"
+
+          echo "Files in /tmp/digests:"
+          ls -la
+
+          echo "Running docker buildx imagetools create..."
           docker buildx imagetools create "${tag_array[@]}" "${digest_array[@]}"
 
       - name: Inspect image


### PR DESCRIPTION
## Summary
This is a debugging PR to identify the root cause of the digest expansion error in the publish workflow.

- Display tag array contents
- Display digest array contents  
- List files in /tmp/digests directory

Once the issue is identified, this PR will be closed and a proper fix will be implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)