### PR TITLE
fix: separate tag option and value in array expansion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,19 +114,13 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          readarray -t tag_array < <(jq -cr '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          echo "Tag array elements:"
-          printf '%s\n' "${tag_array[@]}"
-
+          readarray -t tag_names < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=()
+          for tag in "${tag_names[@]}"; do
+            tag_args+=("-t" "$tag")
+          done
           readarray -t digest_array < <(printf "${REGISTRY_IMAGE}@sha256:%s\n" *)
-          echo "Digest array elements:"
-          printf '%s\n' "${digest_array[@]}"
-
-          echo "Files in /tmp/digests:"
-          ls -la
-
-          echo "Running docker buildx imagetools create..."
-          docker buildx imagetools create "${tag_array[@]}" "${digest_array[@]}"
+          docker buildx imagetools create "${tag_args[@]}" "${digest_array[@]}"
 
       - name: Inspect image
         env:


### PR DESCRIPTION
## Summary
- Build tag_args array with separate "-t" and tag value elements
- Allows proper quoting while maintaining correct argument separation
- Resolves invalid reference format error in docker buildx imagetools
- No shellcheck warnings

## Root Cause
The previous implementation combined "-t" and the tag value into a single array element (`"-t tag"`), which caused issues when the array was quoted during expansion.

## Solution
Separate "-t" and tag values into individual array elements, allowing proper quoting while maintaining correct argument separation for the docker command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)