### PR TITLE
fix: upgrade pip in app stage to ensure clean installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.13.9-slim-trixie AS builder
 WORKDIR /build/
 COPY --from=ghcr.io/astral-sh/uv:0.9.13 /uv /usr/local/bin/uv
-RUN uv pip install --system pip==25.3 --no-cache
 COPY pyproject.toml /build/
 RUN uv pip install --system -r pyproject.toml --no-cache
 
@@ -9,6 +8,7 @@ FROM python:3.13.9-slim-trixie AS app
 WORKDIR /app/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
+RUN pip install --upgrade pip==25.3
 COPY config/ /app/config/
 COPY main.py /app/
 COPY app/*.py /app/app/


### PR DESCRIPTION
## Summary
- Move pip upgrade to app stage after COPY operations
- Ensures pip 25.2 is properly replaced with 25.3
- Resolves CVE-2025-8869 (MEDIUM severity)

## Root Cause
Previously, pip was upgraded in the builder stage, but when copying `/usr/local/lib/` to the app stage, both pip 25.2 and 25.3 directories were copied, leaving the vulnerability unresolved.

## Solution
Upgrade pip in the app stage after all COPY operations, ensuring pip 25.2 is properly uninstalled and replaced with 25.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)