### PR TITLE
chore: remove Trivy scan from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,9 +127,3 @@ jobs:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${STEPS_META_OUTPUTS_VERSION}"
-
-  trivy:
-    needs: merge
-    uses: ./.github/workflows/trivy.yml
-    permissions:
-      security-events: write


### PR DESCRIPTION
## Summary
- Remove Trivy scan job from publish workflow
- Trivy scan after publish may scan old images due to registry propagation timing
- Daily scheduled scan is sufficient for security monitoring
- Manual workflow_dispatch available for immediate scanning when needed

## Reason
Testing showed that immediately after publishing an image, the Trivy scan sometimes pulled the old image from the registry, likely due to CDN propagation delays. The daily scheduled scan (and manual execution when needed) provides sufficient security monitoring without this timing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)