### PR TITLE
feat: Enable ruff B, I, UP rules and apply fixes

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -4,7 +4,6 @@ This module contains the logic for responding to new Slack posts.
 
 import logging
 import time
-from typing import Optional
 
 from litellm.exceptions import ContextWindowExceededError, Timeout
 from slack_bolt import BoltContext
@@ -192,8 +191,8 @@ def has_parent_post_mentioned(
 
 
 def find_parent_post(
-    client: WebClient, channel_id: Optional[str], thread_ts: Optional[str]
-) -> Optional[dict]:
+    client: WebClient, channel_id: str | None, thread_ts: str | None
+) -> dict | None:
     """
     Finds the parent post of a thread in Slack.
 
@@ -222,7 +221,7 @@ def post_loading_reply(
     channel_id: str,
     payload: dict,
     loading_text: str,
-) -> tuple[Optional[str], SlackResponse]:
+) -> tuple[str | None, SlackResponse]:
     """
     Posts a loading reply to a Slack post in a channel or thread.
 
@@ -460,8 +459,8 @@ def handle_timeout_error(
     *,
     client: WebClient,
     channel_id: str,
-    locale: Optional[str],
-    thread_ts: Optional[str] = None,
+    locale: str | None,
+    thread_ts: str | None = None,
 ):
     """
     Handles timeout errors by posting an error message as a separate reply.
@@ -488,7 +487,7 @@ def handle_context_window_exceeded_error(
     client: WebClient,
     channel_id: str,
     e: ContextWindowExceededError,
-    thread_ts: Optional[str] = None,
+    thread_ts: str | None = None,
 ):
     """
     Handles context window exceeded errors by posting an error message as a separate reply.
@@ -515,7 +514,7 @@ def handle_exception(
     client: WebClient,
     channel_id: str,
     e: Exception,
-    thread_ts: Optional[str] = None,
+    thread_ts: str | None = None,
 ):
     """
     Handles exceptions by posting an error message as a separate reply.

--- a/app/bolt_logic.py
+++ b/app/bolt_logic.py
@@ -2,8 +2,6 @@
 This module contains logic for handling Slack events and interactions.
 """
 
-from typing import Optional
-
 from slack_bolt import BoltContext
 from slack_bolt.authorization.authorize_result import AuthorizeResult
 from slack_bolt.request.payload_utils import is_event
@@ -42,7 +40,7 @@ def should_skip_event(body: dict, payload: dict) -> bool:
     )
 
 
-def extract_user_id_from_context(context: BoltContext) -> Optional[str]:
+def extract_user_id_from_context(context: BoltContext) -> str | None:
     """
     Extract the user ID from a Bolt context object.
 
@@ -81,7 +79,7 @@ def is_post_in_dm(payload: dict) -> bool:
     return payload.get("channel_type") == "im"
 
 
-def is_post_mentioned(bot_user_id: Optional[str], post: Optional[dict]) -> bool:
+def is_post_mentioned(bot_user_id: str | None, post: dict | None) -> bool:
     """
     Checks whether the bot is mentioned in a Slack post.
 
@@ -94,7 +92,7 @@ def is_post_mentioned(bot_user_id: Optional[str], post: Optional[dict]) -> bool:
     return post is not None and f"<@{bot_user_id}>" in post.get("text", "")
 
 
-def determine_thread_ts_to_reply(payload: dict) -> Optional[str]:
+def determine_thread_ts_to_reply(payload: dict) -> str | None:
     """
     Determine the thread timestamp (thread_ts) to reply to.
 
@@ -110,7 +108,7 @@ def determine_thread_ts_to_reply(payload: dict) -> Optional[str]:
     return thread_ts
 
 
-def has_read_files_scope(authorize_result: Optional[AuthorizeResult]) -> bool:
+def has_read_files_scope(authorize_result: AuthorizeResult | None) -> bool:
     """
     Check if the bot has the "files:read" scope.
 

--- a/app/bolt_middlewares.py
+++ b/app/bolt_middlewares.py
@@ -3,7 +3,7 @@ This module contains middleware functions for the Slack Bolt app.
 """
 
 import logging
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from slack_bolt import BoltContext, BoltResponse
 from slack_sdk.web import WebClient
@@ -15,7 +15,7 @@ def before_authorize(
     body: dict,
     payload: dict,
     next_: Callable[[], None],
-) -> Optional[BoltResponse]:
+) -> BoltResponse | None:
     """
     Skip message changed/deleted events to reduce unnecessary workload.
 

--- a/app/home_tab_logic.py
+++ b/app/home_tab_logic.py
@@ -3,7 +3,6 @@ Logic functions for building home tab blocks.
 """
 
 from datetime import datetime
-from typing import List, Optional
 
 import pytz
 from slack_sdk.models.blocks import (
@@ -112,7 +111,7 @@ def format_timestamp(timestamp: int, user_tz: str) -> str:
 def format_server_display(
     server_name: str,
     is_enabled: bool,
-    expires_at: Optional[int] = None,
+    expires_at: int | None = None,
     user_tz: str = "UTC",
 ) -> str:
     """
@@ -145,8 +144,8 @@ def build_home_tab_blocks(
     user_oauth_sessions: dict[str, dict],
     user_oauth_tools: dict[str, list[dict]],
     user_tz: str,
-    error_message: Optional[str] = None,
-) -> List[Block]:
+    error_message: str | None = None,
+) -> list[Block]:
     """
     Build home tab blocks from configuration and user data.
 
@@ -162,7 +161,7 @@ def build_home_tab_blocks(
     Returns:
         List[Block]: List of Block Kit blocks.
     """
-    blocks: List[Block] = []
+    blocks: list[Block] = []
 
     if error_message:
         blocks.append(
@@ -204,7 +203,7 @@ def build_home_tab_blocks(
     return blocks
 
 
-def build_no_auth_servers_section(mcp_servers: list[dict[str, str]]) -> List[Block]:
+def build_no_auth_servers_section(mcp_servers: list[dict[str, str]]) -> list[Block]:
     """
     Build section for servers without authentication.
 
@@ -214,7 +213,7 @@ def build_no_auth_servers_section(mcp_servers: list[dict[str, str]]) -> List[Blo
     Returns:
         List[Block]: Block Kit blocks for no-auth servers.
     """
-    blocks: List[Block] = []
+    blocks: list[Block] = []
 
     blocks.append(
         HeaderBlock(text=PlainTextObject(text="🌐 MCP Servers without Authentication"))
@@ -239,7 +238,7 @@ def build_no_auth_servers_section(mcp_servers: list[dict[str, str]]) -> List[Blo
     return blocks
 
 
-def build_oauth_servers_section(mcp_servers: List[dict], user_tz: str) -> List[Block]:
+def build_oauth_servers_section(mcp_servers: list[dict], user_tz: str) -> list[Block]:
     """
     Build section for servers requiring authentication.
 
@@ -250,7 +249,7 @@ def build_oauth_servers_section(mcp_servers: List[dict], user_tz: str) -> List[B
     Returns:
         List[Block]: Block Kit blocks for auth servers.
     """
-    blocks: List[Block] = []
+    blocks: list[Block] = []
 
     if not mcp_servers:
         return blocks
@@ -352,7 +351,7 @@ def build_home_tab_view(
     user_oauth_sessions: dict[str, dict],
     user_oauth_tools: dict[str, list[dict]],
     user_tz: str,
-    error_message: Optional[str] = None,
+    error_message: str | None = None,
 ) -> View:
     """
     Build complete home tab view with all blocks.

--- a/app/home_tab_service.py
+++ b/app/home_tab_service.py
@@ -2,8 +2,6 @@
 Service functions for home tab that have side effects or external dependencies.
 """
 
-from typing import Optional
-
 from slack_sdk import WebClient
 
 from app.home_tab_logic import build_home_tab_view
@@ -43,7 +41,7 @@ def get_user_timezone(client: WebClient, user_id: str) -> str:
 def update_home_tab(
     client: WebClient,
     user_id: str,
-    error_message: Optional[str] = None,
+    error_message: str | None = None,
 ) -> None:
     """
     Update home tab by fetching all data from mcp_service.

--- a/app/litellm_logic.py
+++ b/app/litellm_logic.py
@@ -2,12 +2,10 @@
 This module contains logic related to LiteLLM.
 """
 
-from typing import Optional
-
 from litellm.types.utils import ModelResponse
 
 
-def extract_delta_content(chunk: ModelResponse) -> Optional[str]:
+def extract_delta_content(chunk: ModelResponse) -> str | None:
     """
     Extract the delta content from a chunk of model response.
 

--- a/app/mcp/agentcore_service.py
+++ b/app/mcp/agentcore_service.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import secrets
 import time
-from typing import Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
 
 from bedrock_agentcore.services.identity import IdentityClient, TokenPoller
 
@@ -16,7 +16,7 @@ from app.mcp.agentcore_logic import create_agentcore_user_id
 OAUTH_POLLING_TIMEOUT_SECONDS = 300
 OAUTH_POLLING_INTERVAL_SECONDS = 5
 
-active_oauth_pollers: dict[str, "CancellableTokenPoller"] = {}
+active_oauth_pollers: dict[str, CancellableTokenPoller] = {}
 
 
 def create_poller_key(user_id: str, server_name: str) -> str:
@@ -30,7 +30,7 @@ class CancellableTokenPoller(TokenPoller):
     def __init__(
         self,
         auth_url: str,
-        func: Callable[[], Optional[str]],
+        func: Callable[[], str | None],
         user_id: str,
         server_name: str,
     ):
@@ -176,7 +176,7 @@ async def initiate_oauth_flow_with_callback(
     callback_url: str,
     on_auth_url_callback: Callable[[str, str], None],
     on_token_callback: Callable[[str], Awaitable[None]],
-    on_timeout_callback: Optional[Callable[[], None]] = None,
+    on_timeout_callback: Callable[[], None] | None = None,
 ) -> None:
     """
     Initiate OAuth flow using callbacks for auth URL and token.

--- a/app/mcp/config_logic.py
+++ b/app/mcp/config_logic.py
@@ -2,8 +2,6 @@
 This module provides pure logic functions for MCP configuration.
 """
 
-from typing import Optional
-
 DEFAULT_AUTH_SESSION_DURATION_MINUTES = 30
 DEFAULT_WORKLOAD_NAME = "Collmbo"
 DEFAULT_AGENTCORE_REGION = "us-west-2"
@@ -47,7 +45,7 @@ def get_oauth_server_from_config(mcp_config: dict, server_index: int) -> dict:
 def get_oauth_server_index_from_config(
     mcp_config: dict,
     server_name: str,
-) -> Optional[int]:
+) -> int | None:
     """
     Get OAuth server index by name from config.
 
@@ -82,7 +80,7 @@ def get_no_auth_servers_from_config(mcp_config: dict) -> list[dict[str, str]]:
     return servers
 
 
-def normalize_mcp_config(raw_mcp_config: Optional[dict]) -> dict:
+def normalize_mcp_config(raw_mcp_config: dict | None) -> dict:
     """
     Normalize MCP configuration data with default values.
 

--- a/app/mcp/config_service.py
+++ b/app/mcp/config_service.py
@@ -3,7 +3,6 @@ This module provides service functions for MCP configuration.
 """
 
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
@@ -19,7 +18,7 @@ from app.mcp.config_logic import (
 
 CONFIG_FILE_PATH = "config/mcp.yml"
 
-mcp_config: Optional[dict] = None
+mcp_config: dict | None = None
 
 
 def load_mcp_config() -> dict:
@@ -32,7 +31,7 @@ def load_mcp_config() -> dict:
     config_data = None
     path = Path(CONFIG_FILE_PATH)
     if path.exists():
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
     return normalize_mcp_config(config_data)
 
@@ -86,7 +85,7 @@ def get_oauth_server(server_index: int) -> dict:
     return get_oauth_server_from_config(config, server_index)
 
 
-def get_oauth_server_index(server_name: str) -> Optional[int]:
+def get_oauth_server_index(server_name: str) -> int | None:
     """
     Get OAuth server index by name.
 

--- a/app/mcp/no_auth_tools_service.py
+++ b/app/mcp/no_auth_tools_service.py
@@ -5,6 +5,7 @@ Service functions for no-auth MCP tools integration.
 import logging
 import threading
 import time
+from functools import partial
 
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp.mcp_client import MCPClient
@@ -28,7 +29,7 @@ def load_no_auth_mcp_tools() -> None:
     for idx, server in enumerate(no_auth_servers):
         url = server["url"]
         try:
-            client = MCPClient(lambda: streamablehttp_client(url))
+            client = MCPClient(partial(streamablehttp_client, url))
             with client:
                 tools = client.list_tools_sync()
             result.extend(

--- a/app/mcp/oauth_control_service.py
+++ b/app/mcp/oauth_control_service.py
@@ -5,7 +5,7 @@ Service functions for MCP servers with OAuth authentication.
 import asyncio
 import concurrent.futures
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from slack_sdk import WebClient
 

--- a/app/mcp/oauth_tools_logic.py
+++ b/app/mcp/oauth_tools_logic.py
@@ -2,8 +2,6 @@
 Logic functions for OAuth session management.
 """
 
-from typing import Optional
-
 from app.mcp.tools_logic import (
     AUTH_TYPE_ABBREVIATIONS,
     MCP_TOOL_NAME_SEPARATOR,
@@ -11,7 +9,7 @@ from app.mcp.tools_logic import (
 )
 
 
-def is_session_not_expired(session: Optional[dict], timestamp: int) -> bool:
+def is_session_not_expired(session: dict | None, timestamp: int) -> bool:
     """
     Check if authentication session has not expired.
 
@@ -29,7 +27,7 @@ def is_session_not_expired(session: Optional[dict], timestamp: int) -> bool:
 
 def create_bearer_auth_headers(
     token: str,
-    additional_headers: Optional[dict[str, str]] = None,
+    additional_headers: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """
     Create authorization headers for Bearer token authentication.

--- a/app/mcp/oauth_tools_service.py
+++ b/app/mcp/oauth_tools_service.py
@@ -21,7 +21,7 @@ def set_user_oauth_session(
     server_name: str,
     token: str,
     expires_at: int,
-    tools: list[dict] = [],
+    tools: list[dict] | None = None,
 ) -> None:
     """
     Set OAuth session for a specific user and server.
@@ -31,8 +31,10 @@ def set_user_oauth_session(
         server_name (str): The MCP server name.
         token (str): The OAuth token.
         expires_at (int): Unix timestamp when the token expires.
-        tools (list[dict]): Tools list to store with session.
+        tools (list[dict] | None): Tools list to store with session.
     """
+    if tools is None:
+        tools = []
     if user_id not in user_oauth_sessions:
         user_oauth_sessions[user_id] = {}
     user_oauth_sessions[user_id][server_name] = {
@@ -261,11 +263,11 @@ def process_oauth_mcp_tool_call(
             )
         content = result["content"][0]
         return content.get("text", "")
-    except MCPClientInitializationError:
+    except MCPClientInitializationError as err:
         # MCP client failed to initialize, likely due to authentication error
         # Clear the invalid session and cached tools
         clear_user_oauth_session(user_id, server_config["name"])
         raise RuntimeError(
             f"Authentication error for {server_config['name']}. "
             "Please visit the Home tab to re-authorize."
-        )
+        ) from err

--- a/app/message_logic.py
+++ b/app/message_logic.py
@@ -5,13 +5,12 @@ This module contains functions to handle message logic.
 import base64
 import re
 import unicodedata
-from typing import Optional
 
 
 def is_last_marker_reply(
     *,
     reply: dict,
-    bot_user_id: Optional[str],
+    bot_user_id: str | None,
     marker_text: str,
 ) -> bool:
     """
@@ -31,7 +30,7 @@ def is_last_marker_reply(
 def filter_replies_after_last_marker(
     *,
     replies: list[dict],
-    bot_user_id: Optional[str],
+    bot_user_id: str | None,
     marker_text: str,
 ) -> list[dict]:
     """
@@ -58,7 +57,7 @@ def filter_replies_after_last_marker(
 
 def build_system_message(
     system_text_template: str,
-    bot_user_id: Optional[str],
+    bot_user_id: str | None,
     translate_markdown: bool,
     prompt_caching_enabled: bool,
 ) -> dict:
@@ -154,7 +153,7 @@ def build_image_url_item(mime_type: str, image_bytes: bytes) -> dict:
     }
 
 
-def build_pdf_file_item(filename: Optional[str], pdf_bytes: bytes) -> dict:
+def build_pdf_file_item(filename: str | None, pdf_bytes: bytes) -> dict:
     """
     Build a PDF file item for the bot.
 
@@ -175,7 +174,7 @@ def build_pdf_file_item(filename: Optional[str], pdf_bytes: bytes) -> dict:
     }
 
 
-def remove_bot_mention(text: str, bot_user_id: Optional[str]) -> str:
+def remove_bot_mention(text: str, bot_user_id: str | None) -> str:
     """
     Remove the bot mention from the text.
 

--- a/app/slack_image_service.py
+++ b/app/slack_image_service.py
@@ -4,7 +4,6 @@ This module provides functionality to handle images from Slack files.
 
 import logging
 from io import BytesIO
-from typing import Optional
 
 from PIL import Image
 
@@ -18,7 +17,7 @@ SUPPORTED_IMAGE_MIME_TYPES = [f"image/{fmt}" for fmt in SUPPORTED_IMAGE_FORMATS]
 def build_image_url_items_from_slack_files(
     *,
     bot_token: str,
-    files: Optional[list[dict]],
+    files: list[dict] | None,
 ) -> list[dict]:
     """
     Build image URL items from Slack files.

--- a/app/slack_pdf_service.py
+++ b/app/slack_pdf_service.py
@@ -3,7 +3,6 @@ This module provides functionality to handle PDFs from Slack files.
 """
 
 import logging
-from typing import Optional
 
 from app.message_logic import build_pdf_file_item
 from app.slack_file_service import get_slack_file_content
@@ -12,7 +11,7 @@ from app.slack_file_service import get_slack_file_content
 def build_pdf_file_items_from_slack_files(
     *,
     bot_token: str,
-    files: Optional[list[dict]],
+    files: list[dict] | None,
     pdf_slots: int = 5,
     used_pdf_slots: int = 0,
 ) -> list[dict]:

--- a/app/tools_logic.py
+++ b/app/tools_logic.py
@@ -3,7 +3,6 @@ This module provides logical functions for tools.
 """
 
 from importlib import import_module
-from typing import Optional
 
 from app.mcp.tools_logic import (
     AUTH_TYPE_ABBREVIATIONS,
@@ -28,7 +27,7 @@ def is_mcp_tool_name(name: str) -> bool:
     return MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI in name or MCP_TOOL_NAME_SEPARATOR in name
 
 
-def load_classic_tools(module_name: Optional[str]) -> list[dict]:
+def load_classic_tools(module_name: str | None) -> list[dict]:
     """
     Load tools from a module.
 

--- a/app/tools_service.py
+++ b/app/tools_service.py
@@ -6,7 +6,6 @@ import json
 import logging
 from importlib import import_module
 from types import ModuleType
-from typing import Optional
 
 from litellm.types.utils import ChatCompletionMessageToolCall, Message
 
@@ -25,7 +24,7 @@ from app.mcp.oauth_tools_service import (
 from app.message_logic import build_tool_message
 from app.tools_logic import is_mcp_tool_name, load_classic_tools
 
-classic_tools: Optional[list[dict]] = None
+classic_tools: list[dict] | None = None
 
 
 def get_classic_tools() -> list[dict]:
@@ -42,8 +41,8 @@ def get_classic_tools() -> list[dict]:
 
 
 def get_all_tools(
-    channel: Optional[str] = None,
-    user_id: Optional[str] = None,
+    channel: str | None = None,
+    user_id: str | None = None,
 ) -> list[dict]:
     """
     Retrieves all tools, including classic and MCP tools.
@@ -74,7 +73,7 @@ def process_tool_calls(
     response_message: Message,
     assistant_message: dict,
     messages: list[dict],
-    user_id: Optional[str] = None,
+    user_id: str | None = None,
 ) -> None:
     """
     Processes the tool calls in the response message.
@@ -110,7 +109,7 @@ def process_tool_call(
     tool_call: ChatCompletionMessageToolCall,
     messages: list[dict],
     no_auth_server_urls: list[str],
-    user_id: Optional[str] = None,
+    user_id: str | None = None,
 ) -> None:
     """
     Processes a single tool call and updates the messages list.

--- a/app/translation_logic.py
+++ b/app/translation_logic.py
@@ -2,12 +2,10 @@
 Provides logic for handling translations.
 """
 
-from typing import Optional
-
 
 def get_lang_from_locale(
-    locale: Optional[str], locale_to_lang: dict[str, str]
-) -> Optional[str]:
+    locale: str | None, locale_to_lang: dict[str, str]
+) -> str | None:
     """
     Get the language from the locale string.
 
@@ -40,7 +38,7 @@ def get_cached_translation(
     cache: dict[str, str],
     lang: str,
     original: str,
-) -> Optional[str]:
+) -> str | None:
     """
     Get the cached translation for the given language and original text.
 

--- a/app/translation_service.py
+++ b/app/translation_service.py
@@ -2,8 +2,6 @@
 Provides functionality to translate text based on the user's locale.
 """
 
-from typing import Optional
-
 from litellm.types.utils import ModelResponse
 
 from app.litellm_service import call_litellm_completion
@@ -34,7 +32,7 @@ LOCALE_TO_LANG = {
 _translation_result_cache: dict[str, str] = {}
 
 
-def translate(locale: Optional[str], text: str) -> str:
+def translate(locale: str | None, text: str) -> str:
     """
     Translate the given text into the language specified by the locale.
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ import re
 import signal
 import sys
 from types import FrameType
-from typing import Optional
 
 from slack_bolt import Ack, App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -113,7 +112,7 @@ def register_signal_handlers(slack_handler: SocketModeHandler) -> None:
         None
     """
 
-    def handler(signum: int, _: Optional[FrameType]) -> None:
+    def handler(signum: int, _: FrameType | None) -> None:
         logging.info("Received %s, shutting down...", signal.Signals(signum).name)
         shutdown_all_oauth_pollers()
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "zizmor==1.18.0",
 ]
 
+[tool.ruff.lint]
+extend-select = ["B", "I", "UP"]
+
 [tool.uv]
 override-dependencies = [
     "grpcio==1.76.0",  # Force grpcio 1.76.0 for Python 3.14 wheel support

--- a/validate.sh
+++ b/validate.sh
@@ -4,10 +4,10 @@ set -e
 uv sync --extra dev
 
 if [[ "$1" == "ci" ]]; then
-  uv run ruff check --select I ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
+  uv run ruff check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
   uv run ruff format --check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
 else
-  uv run ruff check --select I --fix ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
+  uv run ruff check --fix ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
   uv run ruff format ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
 fi
 uv run mypy ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py


### PR DESCRIPTION
## Summary
- Add `[tool.ruff.lint]` section to pyproject.toml with `extend-select = ["B", "I", "UP"]`
- Remove `--select I` from validate.sh (now configured in pyproject.toml)
- Apply UP rule fixes: `Optional[X]` → `X | None`, `typing` imports → `collections.abc`
- Fix B006: Use `None` default instead of mutable list
- Fix B023: Use `functools.partial` instead of lambda in loop
- Fix B904: Add `from err` to raise statement

## Test plan
- [x] `./validate.sh` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)