### PR TITLE
ci: Use uv python install instead of setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version: "3.14"
-
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
         with:
           version: "0.9.16"
+
+      - name: Install Python
+        run: uv python install 3.14
 
       - name: Run validation script
         run: bash validate.sh ci


### PR DESCRIPTION
## Summary
- Replace `actions/setup-python` with `uv python install` in CI workflow
- Unify Python management under uv
- Enable Python caching via uv's cache mechanism

## Test plan
- [ ] CI workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)