### PR TITLE
chore: Remove unused .flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 125


### PR DESCRIPTION
## Summary
- Remove `.flake8` config file that is no longer used since migrating to ruff

## Test plan
- N/A (config file removal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)