### PR TITLE
fix: remove v prefix from trivy-action version tag

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,7 +20,7 @@ jobs:
           docker pull "${REGISTRY_IMAGE}:latest"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         env:
           REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         with:


### PR DESCRIPTION
## Summary
- Remove 'v' prefix from trivy-action version tag comment in workflow file
- Change from `# v0.33.1` to `# 0.33.1` to match actual GitHub tag format

## Rationale
Renovate was unable to track trivy-action updates because the comment specified `v0.33.1` while the actual GitHub repository uses `0.33.1` (without v prefix). This mismatch prevented Renovate from finding the tag and updating the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)