### PR TITLE
chore: configure Renovate package grouping and automerge rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,5 +17,17 @@
       ],
       "datasourceTemplate": "go"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
+      "matchPackagePatterns": ["astral-sh/uv", "ghcr.io/astral-sh/uv"],
+      "groupName": "astral-sh/uv"
+    },
+    {
+      "description": "Automerge patch updates",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Group astral-sh/uv updates across Dockerfile and GitHub Actions to maintain version consistency
- Enable automerge for patch updates to expedite security fixes and bug fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)