### PR TITLE
chore: use explicit package names instead of regex in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,8 +23,8 @@
       "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
       "groupName": "astral-sh/uv",
       "matchPackageNames": [
-        "/astral-sh/uv/",
-        "/ghcr.io/astral-sh/uv/"
+        "astral-sh/uv",
+        "ghcr.io/astral-sh/uv"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Changed `matchPackageNames` from regex patterns to explicit string matches
- `/astral-sh/uv/` → `"astral-sh/uv"`
- `/ghcr.io/astral-sh/uv/` → `"ghcr.io/astral-sh/uv"`

This improves clarity and maintainability of the renovate configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)