### PR TITLE
chore(renovate): Add hostRules for dhi.io authentication

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,5 +34,12 @@
       ],
       "automerge": true
     }
+  ],
+  "hostRules": [
+    {
+      "matchHost": "dhi.io",
+      "username": "{{ secrets.MEND_DHI_USERNAME }}",
+      "password": "{{ secrets.MEND_DHI_PASSWORD }}"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Add hostRules configuration to authenticate with dhi.io registry
- Use MEND_DHI_USERNAME and MEND_DHI_PASSWORD secrets for credentials

## Test plan
- [ ] Verify Renovate can authenticate with dhi.io when scanning dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)