### PR TITLE
chore(renovate): Add dhi.io as private Docker registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,11 +33,24 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "description": "Force dhi.io to be treated as a private registry instead of Docker Hub",
+      "matchPackageNames": [
+        "dhi.io/**"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "registryUrls": [
+        "https://dhi.io"
+      ]
     }
   ],
   "hostRules": [
     {
       "matchHost": "dhi.io",
+      "hostType": "docker",
       "username": "{{ secrets.MEND_DHI_USERNAME }}",
       "password": "{{ secrets.MEND_DHI_PASSWORD }}"
     }


### PR DESCRIPTION
## Summary
- Add packageRules to treat dhi.io as a private Docker registry instead of Docker Hub
- Add hostRules with Docker hostType for authentication using secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)