### PR TITLE
chore(renovate): Add docker-specific hostRules for dhi.io

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
       "automerge": true
     },
     {
-      "description": "Force dhi.io lookup",
+      "description": "Force dhi.io lookup by datasource override",
       "matchPackageNames": [
         "dhi.io/python"
       ],
@@ -54,5 +54,14 @@
       "username": "{{ secrets.MEND_DHI_USERNAME }}",
       "password": "{{ secrets.MEND_DHI_PASSWORD }}"
     }
-  ]
+  ],
+  "docker": {
+    "hostRules": [
+      {
+        "matchHost": "dhi.io",
+        "username": "{{ secrets.MEND_DHI_USERNAME }}",
+        "password": "{{ secrets.MEND_DHI_PASSWORD }}"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Add hostRules in both top-level and docker-specific sections
- Ensure authentication works for dhi.io private registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)