### PR TITLE
chore(renovate): Use customManager for dhi.io Docker images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,13 @@
   "customManagers": [
     {
       "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": ["FROM (?<depName>dhi\\.io/[^\\s:]+):(?<currentValue>[^\\s@]+)"],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://dhi.io"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github/workflows/.+\\.ya?ml$/"
       ],
@@ -19,6 +26,11 @@
     }
   ],
   "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["dhi.io/**"],
+      "enabled": false
+    },
     {
       "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
       "groupName": "astral-sh/uv",
@@ -33,18 +45,6 @@
         "patch"
       ],
       "automerge": true
-    },
-    {
-      "description": "Force dhi.io lookup by datasource override",
-      "matchPackageNames": [
-        "dhi.io/python"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "registryUrls": [
-        "https://dhi.io"
-      ]
     }
   ],
   "hostRules": [
@@ -54,14 +54,5 @@
       "username": "{{ secrets.MEND_DHI_USERNAME }}",
       "password": "{{ secrets.MEND_DHI_PASSWORD }}"
     }
-  ],
-  "docker": {
-    "hostRules": [
-      {
-        "matchHost": "dhi.io",
-        "username": "{{ secrets.MEND_DHI_USERNAME }}",
-        "password": "{{ secrets.MEND_DHI_PASSWORD }}"
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add regex customManager to parse dhi.io images from Dockerfile with explicit registryUrlTemplate
- Disable standard dockerfile manager for dhi.io packages to avoid Docker Hub misidentification
- Keep hostRules for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)