### PR TITLE
chore(renovate): Use registryAliases for dhi.io

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,16 +6,10 @@
   "labels": [
     "dependencies"
   ],
+  "registryAliases": {
+    "dhi.io": "https://dhi.io"
+  },
   "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)Dockerfile$"],
-      "matchStrings": [
-        "FROM (?<depName>dhi\\.io/(?<packageName>[^\\s:]+)):(?<currentValue>[^\\s@]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "registryUrlTemplate": "https://dhi.io"
-    },
     {
       "customType": "regex",
       "managerFilePatterns": [
@@ -28,11 +22,6 @@
     }
   ],
   "packageRules": [
-    {
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["dhi.io/**"],
-      "enabled": false
-    },
     {
       "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
       "groupName": "astral-sh/uv",


### PR DESCRIPTION
## Summary
- Add registryAliases to map dhi.io to https://dhi.io
- Remove customManager approach in favor of standard dockerfile manager
- Keep hostRules for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)