### PR TITLE
chore(renovate): Fix registryAliases for dhi.io

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "dependencies"
   ],
   "registryAliases": {
-    "dhi.io": "https://dhi.io"
+    "dhi.io": "dhi.io"
   },
   "customManagers": [
     {


### PR DESCRIPTION
## Summary
- Use dhi.io without https scheme in registryAliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)