### PR TITLE
chore(renovate): Remove uv grouping rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,14 +23,6 @@
   ],
   "packageRules": [
     {
-      "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
-      "groupName": "astral-sh/uv",
-      "matchPackageNames": [
-        "astral-sh/uv",
-        "ghcr.io/astral-sh/uv"
-      ]
-    },
-    {
       "description": "Automerge minor and patch updates",
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary
- Remove the groupName rule for astral-sh/uv that was not working as intended
- GitHub Actions and Docker dependencies will now be updated separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)