### PR TITLE
fix(renovate): Add packageRule for dhi.io/python lookup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["dhi.io/python"],
+      "description": "Enable lookup for dhi.io/python"
+    },
+    {
       "description": "Automerge minor and patch updates",
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary
- Add explicit packageRule for dhi.io/python to try triggering Docker registry authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)