### PR TITLE
Revert renovate config changes (#567, #568)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,14 @@
   ],
   "packageRules": [
     {
+      "description": "Group astral-sh/uv across Dockerfile and GitHub Actions",
+      "groupName": "astral-sh/uv",
+      "matchPackageNames": [
+        "astral-sh/uv",
+        "ghcr.io/astral-sh/uv"
+      ]
+    },
+    {
       "description": "Automerge minor and patch updates",
       "matchUpdateTypes": [
         "minor",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,10 +23,6 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["dhi.io/python"],
-      "description": "Enable lookup for dhi.io/python"
-    },
-    {
       "description": "Automerge minor and patch updates",
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary
- Revert #568 (fix/dhi-python-lookup)
- Revert #567 (chore/remove-uv-grouping)

Removing uv grouping rule caused dhi.io/python lookup to fail. Reverting until root cause is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)