### PR TITLE
chore(renovate): Remove hostRules from config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,13 +42,5 @@
       ],
       "automerge": true
     }
-  ],
-  "hostRules": [
-    {
-      "matchHost": "dhi.io",
-      "hostType": "docker",
-      "username": "{{ secrets.MEND_DHI_USERNAME }}",
-      "password": "{{ secrets.MEND_DHI_PASSWORD }}"
-    }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove hostRules from renovate.json
- Migrate to Renovate portal configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)