### PR TITLE
fix: use multi-arch manifest digest for uv image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM dhi.io/python:3.14.2-debian13-dev@sha256:84c62df9f2a1fe35903c347a7c05fe8b62484baa49c40b1005f7b5c0c88b10f6 AS builder
 WORKDIR /build/
-COPY --from=ghcr.io/astral-sh/uv:0.9.21@sha256:4c55b48c2750a257fa631f31d8362445d9f880ba219d871c33153b165a83c81a /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.9.21@sha256:15f68a476b768083505fe1dbfcc998344d0135f0ca1b8465c4760b323904f05a /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock /build/
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
## Summary
- Fix ARM64 build failure caused by using amd64-only SHA digest for uv image
- Use manifest list digest instead of architecture-specific digest

## Problem
The previous PR (#576) used `sha256:4c55b48c...` which was the amd64-specific image digest. This caused ARM64 builds to fail with "Exec format error".

## Solution
Use the manifest list digest `sha256:15f68a47...` which allows Docker to automatically select the correct architecture.

## Test plan
- [ ] Verify ARM64 build succeeds
- [x] Verify AMD64 build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)