### PR TITLE
chore: use config:best-practices preset for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
## Summary
- Switch from `config:recommended` to `config:best-practices` preset
- Enables automatic SHA digest pinning for Docker images and GitHub Actions

## What's included in `config:best-practices`
- `docker:pinDigests` - Auto-pin Docker image digests
- `helpers:pinGitHubActionDigests` - Auto-pin GitHub Actions digests
- `:configMigration` - Auto-migrate config when needed
- `:pinDevDependencies` - Pin dev dependencies
- `abandonments:recommended` - Warn about abandoned packages

## Test plan
- [ ] Verify Renovate runs successfully with new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)