### PR TITLE
fix: improve dhi.io registry handling in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,17 @@
   "customManagers": [
     {
       "customType": "regex",
+      "fileMatch": [
+        "Dockerfile"
+      ],
+      "matchStrings": [
+        "FROM (?<depName>dhi\\.io/(?<packageName>[^\\s@:]+)):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://dhi.io"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": [
         "^\\.github/workflows/.+\\.ya?ml$"
       ],
@@ -23,16 +34,14 @@
   ],
   "packageRules": [
     {
-      "description": "Force dhi.io images to use the correct registry URL to prevent Docker Hub fallback",
+      "description": "Disable default dockerfile manager for dhi.io to prevent duplicate/failed lookups",
       "matchPackageNames": [
         "dhi.io/**"
       ],
-      "matchDatasources": [
-        "docker"
+      "matchManagers": [
+        "dockerfile"
       ],
-      "registryUrls": [
-        "https://dhi.io"
-      ]
+      "enabled": false
     },
     {
       "description": "Automerge minor and patch updates",


### PR DESCRIPTION
## Summary
- Add custom regex manager to explicitly handle dhi.io Docker images with SHA256 digest support
- Disable default dockerfile manager for dhi.io packages to prevent duplicate lookups and Docker Hub fallback issues

## Changes
- Added new `customManagers` entry with regex pattern to match `dhi.io` Docker images in Dockerfiles
- Modified `packageRules` to disable the default `dockerfile` manager for `dhi.io/**` packages
- This ensures Renovate uses only the custom manager for dhi.io registry, avoiding conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)