### PR TITLE
Revert dhi.io Renovate configuration changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,17 +12,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "Dockerfile"
-      ],
-      "matchStrings": [
-        "FROM (?<depName>dhi\\.io/(?<packageName>[^\\s@:]+)):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
-      ],
-      "datasourceTemplate": "docker",
-      "registryUrlTemplate": "https://dhi.io"
-    },
-    {
-      "customType": "regex",
       "managerFilePatterns": [
         "^\\.github/workflows/.+\\.ya?ml$"
       ],
@@ -34,14 +23,16 @@
   ],
   "packageRules": [
     {
-      "description": "Disable default dockerfile manager for dhi.io to prevent duplicate/failed lookups",
+      "description": "Force dhi.io images to use the correct registry URL to prevent Docker Hub fallback",
       "matchPackageNames": [
         "dhi.io/**"
       ],
-      "matchManagers": [
-        "dockerfile"
+      "matchDatasources": [
+        "docker"
       ],
-      "enabled": false
+      "registryUrls": [
+        "https://dhi.io"
+      ]
     },
     {
       "description": "Automerge minor and patch updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/Dockerfile/"
+      "fileMatch": [
+        "Dockerfile"
       ],
       "matchStrings": [
         "FROM (?<depName>dhi\\.io/(?<packageName>[^\\s@:]+)):(?<currentValue>[^\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"


### PR DESCRIPTION
## Summary
Revert PR #580 and PR #581 to restore the original Renovate configuration before dhi.io custom manager changes.

## Reverted PRs
- PR #581: Renovate config migration
- PR #580: dhi.io registry handling improvements

## Context
Testing whether these changes affected dependency detection. Will investigate the root cause and implement a proper fix after confirming the baseline behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)