### PR TITLE
fix: correct regex pattern syntax in Renovate custom manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,12 +13,13 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "^\\.github/workflows/.+\\.ya?ml$"
+        "/^\\.github/workflows/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "go install (?<depName>.*?)@(?<currentValue>v[0-9.]+)"
+        "go install (?<depName>[^@]+)@(?<currentValue>v[0-9.]+)"
       ],
-      "datasourceTemplate": "go"
+      "datasourceTemplate": "go",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary
- Fix `managerFilePatterns` regex syntax by wrapping pattern with forward slashes
- Improve `depName` regex from `.*?` to `[^@]+` for more precise matching
- Add `versioningTemplate: "semver"` for proper semantic versioning

## Problem
The custom manager for detecting `go install` commands was not working because the regex pattern in `managerFilePatterns` was not properly formatted. According to Renovate documentation, regex patterns must be wrapped with forward slashes like `/pattern/`.

## Changes
**Before:**
```json
"managerFilePatterns": [
  "^\\.github/workflows/.+\\.ya?ml$"
]
```

**After:**
```json
"managerFilePatterns": [
  "/^\\.github/workflows/.+\\.ya?ml$/"
]
```

This should enable Renovate to detect and update `go install` commands in GitHub Actions workflows:
- `github.com/rhysd/actionlint/cmd/actionlint@v1.7.9`
- `github.com/suzuki-shunsuke/ghalint/cmd/ghalint@v1.5.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)