### PR TITLE
fix: auto-rebase Renovate PRs when behind base branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "labels": [
     "dependencies"
   ],
+  "rebaseWhen": "behind-base-branch",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- Add `rebaseWhen: behind-base-branch` to Renovate config to automatically rebase PRs that are out-of-date with the base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)