### PR TITLE
chore(deps): enable lockFileMaintenance for transitive dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
     "dependencies"
   ],
   "rebaseWhen": "behind-base-branch",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Enable Renovate's lockFileMaintenance to update transitive dependencies weekly
- Addresses security vulnerabilities in indirect dependencies (e.g., CVE-2025-69223 in aiohttp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)