### PR TITLE
chore: automerge lockFileMaintenance PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,10 +37,11 @@
       ]
     },
     {
-      "description": "Automerge minor and patch updates",
+      "description": "Automerge minor, patch, and lockFileMaintenance updates",
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "lockFileMaintenance"
       ],
       "automerge": true
     }


### PR DESCRIPTION
## Summary
- Add `lockFileMaintenance` to automerge update types
- Lock file refresh PRs will now be automatically merged after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)