### PR TITLE
refactor: use mise for actionlint and ghalint in lint workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,19 +10,6 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Handle go install in GitHub Actions",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/.+\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "go install (?<depName>[^@]+)@(?<currentValue>v[0-9.]+)"
-      ],
-      "datasourceTemplate": "go"
-    }
-  ],
   "packageRules": [
     {
       "description": "Force dhi.io images to use the correct registry URL",

--- a/.github/workflows/.mise.toml
+++ b/.github/workflows/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+actionlint = "1.7.10"
+ghalint = "1.5.4"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
-        with:
-          working_directory: .github/workflows
 
       - name: Run actionlint
-        run: actionlint
+        run: mise exec --cd .github/workflows -- actionlint
 
       - name: Run ghalint
-        run: ghalint run
+        run: mise exec --cd .github/workflows -- ghalint run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,10 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-      - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      - name: Setup mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
         with:
-          go-version: stable
-
-      - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.10
-
-      - name: Install ghalint
-        run: go install github.com/suzuki-shunsuke/ghalint/cmd/ghalint@v1.5.4
+          working_directory: .github/workflows
 
       - name: Run actionlint
         run: actionlint


### PR DESCRIPTION
## Summary
- Replace `go install` with `mise-action` for managing actionlint and ghalint
- Add `.github/workflows/.mise.toml` for tool version management
- Remove regex customManager from Renovate config (mise.toml is natively supported)

🤖 Generated with [Claude Code](https://claude.ai/code)