### PR TITLE
fix: specify aqua backend for ghalint to enable Renovate detection

### DIFF
--- a/.github/workflows/.mise.toml
+++ b/.github/workflows/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
 actionlint = "1.7.10"
-ghalint = "1.5.4"
+"aqua:suzuki-shunsuke/ghalint" = "1.5.4"


### PR DESCRIPTION
## Summary
- Change `ghalint = "1.5.4"` to `"aqua:suzuki-shunsuke/ghalint" = "1.5.4"`
- Renovate's mise manager doesn't detect ghalint with short name format

🤖 Generated with [Claude Code](https://claude.ai/code)