### PR TITLE
feat: trigger Trivy scan on registry package publish

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,7 +3,8 @@ name: Trivy security scan
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_call:
+  registry_package:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Replace `workflow_call` with `registry_package` trigger
- Trivy scan will now run automatically when a Docker image is published to GHCR
- No more manual execution needed after releases

🤖 Generated with [Claude Code](https://claude.ai/code)