### PR TITLE
fix: compare HIGH/CRITICAL vulnerabilities correctly in Trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check for new HIGH/CRITICAL vulnerabilities
         id: check-new
         run: |
-          jq -r '.runs[].results[]?.ruleId // empty' previous-sarif.json | sort -u > previous-cves.txt
+          jq -r '.runs[].results[] | select(.level == "error") | .ruleId' previous-sarif.json | sort -u > previous-cves.txt
           jq -r '.runs[].results[] | select(.level == "error") | .ruleId' \
             trivy-results.sarif | sort -u > current-high-cves.txt
           comm -23 current-high-cves.txt previous-cves.txt > new-cves.txt


### PR DESCRIPTION
## Summary
- Fix diff logic to compare HIGH/CRITICAL vulnerabilities on both sides
- Previously, vulnerabilities that escalated from MEDIUM to HIGH were not detected as new

🤖 Generated with [Claude Code](https://claude.ai/code)