### PR TITLE
fix: call Trivy scan from publish workflow with explicit tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,8 @@ jobs:
       packages: write
     needs:
       - build
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -134,3 +136,13 @@ jobs:
           STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${STEPS_META_OUTPUTS_VERSION}"
+
+  scan:
+    needs: merge
+    uses: ./.github/workflows/trivy.yml
+    with:
+      tag: ${{ needs.merge.outputs.version }}
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,7 +142,6 @@ jobs:
     uses: ./.github/workflows/trivy.yml
     with:
       tag: ${{ needs.merge.outputs.version }}
-    secrets: inherit
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,8 +3,12 @@ name: Trivy security scan
 on:
   schedule:
     - cron: '0 0 * * *'
-  registry_package:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Image tag to scan'
+        required: true
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -14,12 +18,13 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE_TAG: ${{ inputs.tag || 'latest' }}
     steps:
       - name: Pull Docker image
-        env:
-          REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         run: |
-          docker pull "${REGISTRY_IMAGE}:latest"
+          docker pull "${REGISTRY_IMAGE}:${IMAGE_TAG}"
 
       - name: Get previous SARIF from GitHub
         id: previous
@@ -39,10 +44,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-        env:
-          REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
         with:
-          image-ref: ${{ env.REGISTRY_IMAGE }}:latest
+          image-ref: ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
           output: 'trivy-results.sarif'
 


### PR DESCRIPTION
## Summary
- Remove `registry_package` trigger from trivy.yml (doesn't work reliably with GITHUB_TOKEN)
- Add `workflow_call` trigger to trivy.yml with `tag` input
- Call trivy.yml as a reusable workflow from publish.yml after merge job completes
- Pass explicit image tag to ensure the correct image is scanned

🤖 Generated with [Claude Code](https://claude.com/claude-code)