### PR TITLE
fix: add contents:write permission for SBOM release attachment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,6 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: write
       id-token: write
       packages: write
     needs:


### PR DESCRIPTION
## Summary

- Add `contents: write` permission to sign job for SBOM attachment to GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)