### PR TITLE
fix: disable SBOM upload to release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
       id-token: write
       packages: write
     needs:
@@ -172,6 +171,7 @@ jobs:
           image: ${{ env.REGISTRY_IMAGE }}@${{ needs.merge.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          upload-release-assets: false
 
       - name: Attest SBOM
         env:


### PR DESCRIPTION
## Summary

- Disable SBOM upload to release assets due to immutable release setting
- SBOM is still available via cosign attestation
- Remove unnecessary contents:write permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)