### PR TITLE
fix: remove verify steps due to GitHub Actions hang issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,20 +178,3 @@ jobs:
           DIGEST: ${{ needs.merge.outputs.digest }}
         run: |
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY_IMAGE}@${DIGEST}"
-
-      - name: Verify signature
-        env:
-          DIGEST: ${{ needs.merge.outputs.digest }}
-        run: |
-          cosign verify "${REGISTRY_IMAGE}@${DIGEST}" \
-            --certificate-identity-regexp='https://github.com/enechange/collmbo/.*' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
-
-      - name: Verify SBOM attestation
-        env:
-          DIGEST: ${{ needs.merge.outputs.digest }}
-        run: |
-          cosign verify-attestation "${REGISTRY_IMAGE}@${DIGEST}" \
-            --type spdxjson \
-            --certificate-identity-regexp='https://github.com/enechange/collmbo/.*' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'


### PR DESCRIPTION
## Summary

- Remove signature and SBOM attestation verify steps
- These steps hang in GitHub Actions with large SBOM files (~3MB)
- Known issue: https://github.com/sigstore/cosign/issues/3205
- Verification can be done locally by users if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)