### PR TITLE
feat: trigger Trivy scan after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,3 +178,11 @@ jobs:
           DIGEST: ${{ needs.merge.outputs.digest }}
         run: |
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY_IMAGE}@${DIGEST}"
+
+  scan:
+    needs:
+      - merge
+    permissions:
+      contents: read
+      security-events: write
+    uses: ./.github/workflows/trivy.yml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,6 +3,7 @@ name: Trivy security scan
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to trivy.yml
- Call Trivy scan from publish.yml after merge job
- Sign and scan run in parallel for faster completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)