### PR TITLE
revert: remove Trivy scan trigger from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,11 +178,3 @@ jobs:
           DIGEST: ${{ needs.merge.outputs.digest }}
         run: |
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY_IMAGE}@${DIGEST}"
-
-  scan:
-    needs:
-      - merge
-    permissions:
-      contents: read
-      security-events: write
-    uses: ./.github/workflows/trivy.yml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,7 +3,6 @@ name: Trivy security scan
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove Trivy scan job from publish.yml
- Remove workflow_call trigger from trivy.yml

SARIF upload doesn't use the correct ref when triggered via workflow_call. Reverting to keep Trivy as a standalone daily scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)