### PR TITLE
refactor: move zizmor from validate.sh to lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           dockerfile: Dockerfile
 
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dev = [
     "ty==0.0.10",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
-    "zizmor==1.20.0",
 ]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -318,7 +318,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -344,7 +343,6 @@ requires-dist = [
     { name = "strands-agents-tools", specifier = "==0.2.19" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.10" },
     { name = "websockets", specifier = "==15.0.1" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.20.0" },
 ]
 provides-extras = ["dev"]
 
@@ -2005,22 +2003,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
-]
-
-[[package]]
-name = "zizmor"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/28/90/a4ac78798dc184fc02de3f31850b94fdd1ca75559738cb474b240ab2652c/zizmor-1.20.0.tar.gz", hash = "sha256:b80596a7e537ea53394b08336de6fdb24661a286c849f6c9f34b168d8d1fc101", size = 429931, upload-time = "2026-01-06T00:35:45.326Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/dc/d48e5907cd3e24fcf490b887fa01608a7356225bd5b21cf78738a64ce585/zizmor-1.20.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7b7b1d154f7bf99a27738593b262494c922a9d45250889eb070abf352df92f0a", size = 7801558, upload-time = "2026-01-06T00:35:48.15Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ee/4f45e47825b5d6fd2b3e1a225e6deb48759b1614c682cdf81774fffbbe0a/zizmor-1.20.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4679efa9edaa3005e21f421f6d98ef4f7a5dc62fc323c42ac9ca3aa616ebb9b8", size = 7440985, upload-time = "2026-01-06T00:35:40.09Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/0c/09b454b85ccefd5b3c047a65ab8faadf16bf59f4a9d10321523a8f78f7a1/zizmor-1.20.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:8672550f6d80f41609ecb2228826f18c8bd6f6397517aefe28e1fd84a0aea3ff", size = 7732088, upload-time = "2026-01-06T00:35:36.642Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/95/1d4cb59263d6c9f60c16cd2e829d4f24b5e4f65ea168e06b9b7646a227ba/zizmor-1.20.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:1d67fa2f68a2fc386f21388caa8f22b463861aa4122f21f6d6176ef1e35f1f5a", size = 7449073, upload-time = "2026-01-06T00:35:41.814Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/75/821762f751989120aaec7242bde0dfa819416215916881659b0ac2e9ad2d/zizmor-1.20.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6085249dd9a4224885a5575e8b1af5bdc4cf46c6f8641079646dc85c0e27a506", size = 7987686, upload-time = "2026-01-06T00:35:51.712Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/10/617a53ea3859a67dc57f3b39e7fc0eac7dceb7c9311e62070856f7fc33ff/zizmor-1.20.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1c24f7afe7131ac45e916b24bb0e99c1d3a938a0c70504b0298faa499f1b7306", size = 7752542, upload-time = "2026-01-06T00:35:50.064Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/d5/90e42006ec04d2fc2d2405f991a7690807a1cff8038cb62ac097c5eb0e78/zizmor-1.20.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5cae20372c00720e8de2938bec135ade191c3619571753b9ecb43dee1adfaf5e", size = 7452418, upload-time = "2026-01-06T00:35:46.51Z" },
-    { url = "https://files.pythonhosted.org/packages/91/8d/885ac52529b5a731de128c8952472c3f5a4e6680f4f00d91601d140b234c/zizmor-1.20.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:eff403cd9f623a0ff39954f6cb006f3b38ece751efee26ab5d17f7a0fc63f29a", size = 8097268, upload-time = "2026-01-06T00:35:43.477Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/14/9d8b856af299336ca8b43feb4732d898d54d3e94361dace60b06cbcdc6f8/zizmor-1.20.0-py3-none-win32.whl", hash = "sha256:02c19027df384c67c03d22d8e793f46d5ce069dca8265d71715455d7e3bb96c1", size = 6602962, upload-time = "2026-01-06T00:35:38.42Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/8d/4b4be117e8c3dfb7c1d5236ca8981756538330a89d148cbd9d117af4ef8d/zizmor-1.20.0-py3-none-win_amd64.whl", hash = "sha256:7787ea46b8689ddc2fb339447445987822fb1a575ac4f527524ee15102379558", size = 7615267, upload-time = "2026-01-06T00:35:34.612Z" },
 ]

--- a/validate.sh
+++ b/validate.sh
@@ -10,17 +10,11 @@ else
   uv run ruff check --fix ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
   uv run ruff format ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
 fi
+
 uv run ty check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
 
 if [[ "$1" == "ci" ]]; then
   uv run pytest --cov=main --cov=app --cov-branch --cov-report=term --cov-report=xml
 else
   uv run pytest --cov=main --cov=app --cov-branch --cov-report=term
-fi
-
-# Check GitHub Actions workflows for security issues
-if [[ "$1" == "ci" ]]; then
-  uv run zizmor .github/workflows/
-else
-  uv run zizmor --fix .github/workflows/
 fi


### PR DESCRIPTION
## Summary

- Move zizmor GitHub Actions security check from validate.sh to lint.yml
- Remove zizmor from Python dev dependencies (pyproject.toml)
- Keep validate.sh focused on Python code validation only (ruff, ty, pytest)
- lint.yml now handles all infrastructure/config linting (hadolint, zizmor, actionlint, ghalint)

This improves separation of concerns:
- **ci.yml → validate.sh**: Python development cycle (local + CI)
- **lint.yml**: Infrastructure/config linting (CI only, PR gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)