### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Disclaimer
+
+This software is provided "as is" without warranty. Security issues will be addressed on a best-effort basis.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's Security Advisory "Report a Vulnerability" feature.
+
+https://github.com/enechange/collmbo/security/advisories/new


### PR DESCRIPTION
## Summary

- Add SECURITY.md with vulnerability reporting instructions
- Direct users to GitHub Security Advisories for private vulnerability reporting
- Include disclaimer about best-effort support

🤖 Generated with [Claude Code](https://claude.com/claude-code)