### PR TITLE
fix: add security-events permission for zizmor SARIF upload

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- Add `security-events: write` permission to lint workflow
- Required for zizmor to upload SARIF results to Code Scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)