### PR TITLE
refactor: make zizmor fail CI instead of uploading to Security tab

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   lint:
@@ -29,7 +28,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          advanced-security: false
 
       - name: Setup mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1


### PR DESCRIPTION
## Summary

- Disable SARIF upload to Security tab (`advanced-security: false`)
- zizmor now fails CI directly when issues are found
- Simpler workflow: check CI log instead of Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)