### PR TITLE
refactor: disable secret scanning in Trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,6 +25,7 @@ jobs:
           image-ref: ${{ env.REGISTRY_IMAGE }}:latest
           format: 'sarif'
           output: 'trivy-results.sarif'
+          scanners: 'vuln'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9


### PR DESCRIPTION
## Summary
- Disable secret scanning in Trivy, keeping only vulnerability scanning
- GitHub already provides secret scanning at the repository level, making Trivy's secret scan redundant
- Improves CI execution time

🤖 Generated with [Claude Code](https://claude.com/claude-code)