### PR TITLE
refactor: simplify validate.sh with pyproject.toml config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv python install
 
       - name: Run validation script
-        run: bash validate.sh ci
+        run: bash validate.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,24 @@ dev = [
     "pytest-cov==7.0.0",
 ]
 
+[tool.ruff]
+include = ["*.py", "app/**/*.py", "tests/**/*.py"]
+
 [tool.ruff.lint]
 extend-select = ["B", "I", "UP"]
+
+[tool.ty.src]
+include = [".", "app", "tests"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["main", "app"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.uv]
 override-dependencies = [

--- a/validate.sh
+++ b/validate.sh
@@ -3,18 +3,14 @@ set -e
 
 uv sync --extra dev
 
-if [[ "$1" == "ci" ]]; then
-  uv run ruff check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
-  uv run ruff format --check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
+if [[ -n "$CI" ]]; then
+  uv run ruff check
+  uv run ruff format --check
+  uv run ty check
+  uv run pytest --cov --cov-report=term --cov-report=xml
 else
-  uv run ruff check --fix ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
-  uv run ruff format ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
-fi
-
-uv run ty check ./*.py ./app/*.py ./app/mcp/*.py ./tests/*.py ./tests/mcp/*.py
-
-if [[ "$1" == "ci" ]]; then
-  uv run pytest --cov=main --cov=app --cov-branch --cov-report=term --cov-report=xml
-else
-  uv run pytest --cov=main --cov=app --cov-branch --cov-report=term
+  uv run ruff check --fix
+  uv run ruff format
+  uv run ty check
+  uv run pytest --cov --cov-report=term
 fi


### PR DESCRIPTION
## Summary
- Move ruff, ty, pytest, and coverage settings to pyproject.toml
- Use $CI environment variable for automatic CI detection
- Consolidate CI/local branches into single if-else block

🤖 Generated with [Claude Code](https://claude.com/claude-code)