### PR TITLE
chore: update Trivy version to v0.68.2

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           scanners: 'vuln'
+          version: 'v0.68.2'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9


### PR DESCRIPTION
## Summary
- Update Trivy version from v0.65.0 to v0.68.2
- trivy-action 0.33.1 uses an older default version, so specify explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)