### PR TITLE
chore: disable Codecov auto-search and specify coverage file explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,5 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          disable_search: true


### PR DESCRIPTION
## Summary
- Specify `coverage.xml` explicitly with `files` parameter
- Disable auto-search to suppress gcov/coverage.py warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)