### PR TITLE
ci: add self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Run Renovate
-        uses: renovatebot/github-action@e084b5ac6fd1493e346ade34a7ae7f271f360def # v42.0.3
+        uses: renovatebot/github-action@a7e89c349a53ab0c9d8458eb85f4b415e55848e7 # v44.2.3
         with:
           configurationFile: .github/renovate.json
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,34 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@e084b5ac6fd1493e346ade34a7ae7f271f360def # v42.0.3
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for self-hosted Renovate
- Use enechange-renovate GitHub App for authentication
- Configure dhi.io Docker registry access via environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)