### PR TITLE
ci: add repository to Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,4 +31,5 @@ jobs:
           configurationFile: .github/renovate.json
           token: ${{ steps.app-token.outputs.token }}
         env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary
- Add RENOVATE_REPOSITORIES environment variable to specify target repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)