### PR TITLE
ci: run Renovate workflow hourly

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Change Renovate schedule from every 6 hours to every hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)