### PR TITLE
ci: run Renovate on push to main

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,8 @@
 name: Renovate
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Run Renovate when changes are pushed to main branch
- Updates Dependency Dashboard immediately after PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)