### PR TITLE
Add issues permission to Renovate workflow for Dependency Dashboard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,6 +27,7 @@ jobs:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
 
       - name: Run Renovate


### PR DESCRIPTION
## Summary
- Add `permission-issues: write` to Renovate GitHub App token to enable Dependency Dashboard issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)