### PR TITLE
Add vulnerability-alerts permission to Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,6 +29,7 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-vulnerability-alerts: read
 
       - name: Run Renovate
         uses: renovatebot/github-action@a7e89c349a53ab0c9d8458eb85f4b415e55848e7 # v44.2.3


### PR DESCRIPTION
## Summary
- Add `permission-vulnerability-alerts: read` to Renovate GitHub App token to fix "Cannot access vulnerability alerts" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)