### PR TITLE
Group Renovate updates by manager type and add digest to automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,10 +45,11 @@
       "groupName": "mise-tools"
     },
     {
-      "description": "Automerge minor, patch, and lockFileMaintenance updates",
+      "description": "Automerge minor, patch, digest, and lockFileMaintenance updates",
       "matchUpdateTypes": [
         "minor",
         "patch",
+        "digest",
         "lockFileMaintenance"
       ],
       "automerge": true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,26 @@
       ]
     },
     {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Docker image updates",
+      "matchManagers": ["dockerfile"],
+      "groupName": "docker"
+    },
+    {
+      "description": "Group Python dependencies",
+      "matchManagers": ["pep621"],
+      "groupName": "python-dependencies"
+    },
+    {
+      "description": "Group mise tool updates",
+      "matchManagers": ["mise"],
+      "groupName": "mise-tools"
+    },
+    {
       "description": "Automerge minor, patch, and lockFileMaintenance updates",
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary
- Group Renovate dependency updates by manager type (github-actions, dockerfile, pep621, mise)
- Add digest updates to automerge targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)