### PR TITLE
Add Docker build cache to Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,9 +30,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Build Docker image
-        run: |
-          docker build -t trivy-scan:${{ github.sha }} .
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          tags: trivy-scan:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1


### PR DESCRIPTION
## Summary
- Use `docker/build-push-action` with GitHub Actions cache (`type=gha`) to speed up Docker builds in Trivy workflow
- Adds `docker/setup-buildx-action` for Buildx support

🤖 Generated with [Claude Code](https://claude.com/claude-code)