### PR TITLE
fix: address code quality warnings

### DIFF
--- a/app/home_tab_logic.py
+++ b/app/home_tab_logic.py
@@ -100,9 +100,9 @@ def format_timestamp(timestamp: int, user_tz: str) -> str:
         dt = datetime.fromtimestamp(timestamp, tz=UTC)
         try:
             user_timezone = ZoneInfo(user_tz)
-            dt = dt.astimezone(user_timezone)
         except (ZoneInfoNotFoundError, AttributeError):
-            pass
+            user_timezone = UTC
+        dt = dt.astimezone(user_timezone)
         return dt.strftime("%H:%M:%S")
     except (ValueError, TypeError, OSError):
         return ""

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,3 +1,3 @@
-# This import includes main.py in the coverage report.
-# Its functions are not tested directly in unit tests due to side effects.
-import main  # noqa: F401
+import main
+
+_ = main  # Mark import as used so static analysis tools do not flag it.


### PR DESCRIPTION
## Summary
- Refactor timezone fallback logic in `format_timestamp` to avoid empty except block
- Suppress unused import warning in `main_test.py` by assigning to `_`

🤖 Generated with [Claude Code](https://claude.com/claude-code)