### PR TITLE
fix: add workflows permission for Renovate to update GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,6 +30,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           permission-vulnerability-alerts: read
+          permission-workflows: write
 
       - name: Run Renovate
         uses: renovatebot/github-action@a7e89c349a53ab0c9d8458eb85f4b415e55848e7 # v44.2.3


### PR DESCRIPTION
## Summary
- Add workflows permission to Renovate GitHub App token
- This allows Renovate to create PRs that include changes to files in `.github/workflows/` (e.g., github-actions group updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)