### PR TITLE
chore(renovate): adjust lockFileMaintenance schedule to JST 3-5am

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "rebaseWhen": "behind-base-branch",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 5am"]
+    "schedule": ["after 6pm and before 8pm"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Change lockFileMaintenance schedule from `before 5am` (UTC) to `after 6pm and before 8pm` (UTC)
- This corresponds to JST 3:00-5:00, ensuring PRs are created and auto-merged before work hours

🤖 Generated with [Claude Code](https://claude.ai/code)