### PR TITLE
ci: add merge_group event for GitHub Merge Queue support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Add `merge_group` event trigger to validate.yml workflow
- This enables GitHub Merge Queue to run CI on queued PRs

After merging, enable "Require merge queue" in branch protection rules.

🤖 Generated with [Claude Code](https://claude.ai/code)