### PR TITLE
fix(tests): use stream=True for ModelResponse in litellm tests

### DIFF
--- a/tests/litellm_logic_test.py
+++ b/tests/litellm_logic_test.py
@@ -10,28 +10,28 @@ from app.litellm_logic import extract_delta_content, is_final_chunk
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=Delta(content="Hello"))],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             "Hello",
         ),
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=Delta(tool_calls=[]))],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             None,
         ),
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=None)],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             None,
         ),
         (
             ModelResponse(
                 choices=[],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             None,
         ),
@@ -49,21 +49,21 @@ def test_extract_delta_content(chunk, expected):
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=Delta(content="Hello"))],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             False,
         ),
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=Delta(), finish_reason="stop")],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             True,
         ),
         (
             ModelResponse(
                 choices=[StreamingChoices(delta=None, finish_reason="length")],
-                object="chat.completion.chunk",
+                stream=True,
             ),
             True,
         ),


### PR DESCRIPTION
## Summary

- Use `stream=True` parameter instead of `object="chat.completion.chunk"` in ModelResponse test fixtures
- Fix compatibility with LiteLLM's updated ModelResponse behavior that converts StreamingChoices to Choices when stream is not set

🤖 Generated with [Claude Code](https://claude.ai/code)