### PR TITLE
revert: remove merge_group event from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Revert PR #676 which added merge_group event for GitHub Merge Queue
- Merge Queue is not needed for this repository's workflow

🤖 Generated with [Claude Code](https://claude.ai/code)