### PR TITLE
chore(renovate): change rebaseWhen to conflicted

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "labels": [
     "dependencies"
   ],
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["after 6pm and before 8pm"]


### PR DESCRIPTION
## Summary

- Change `rebaseWhen` from `behind-base-branch` to `conflicted`
- Reduce unnecessary CI runs by only rebasing when conflicts occur

🤖 Generated with [Claude Code](https://claude.ai/code)