### PR TITLE
chore(renovate): remove PR limits and run lockFileMaintenance anytime

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,11 @@
     "dependencies"
   ],
   "rebaseWhen": "conflicted",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 6pm and before 8pm"]
+    "schedule": ["at any time"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Remove `prHourlyLimit` and `prConcurrentLimit` restrictions (set to 0 for unlimited)
- Change lockFileMaintenance schedule from `"after 6pm and before 8pm"` to `"at any time"`
- Self-hosted Renovate with automerge enabled doesn't need rate limits

🤖 Generated with [Claude Code](https://claude.ai/code)