### PR TITLE
Remove DHI registryUrls packageRule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,39 +11,37 @@
   "prConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["at any time"]
+    "schedule": [
+      "at any time"
+    ]
   },
   "packageRules": [
     {
-      "description": "Force dhi.io images to use the correct registry URL",
-      "matchPackageNames": [
-        "dhi.io/**"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "registryUrls": [
-        "https://dhi.io"
-      ]
-    },
-    {
       "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions"
     },
     {
       "description": "Group Docker image updates",
-      "matchManagers": ["dockerfile"],
+      "matchManagers": [
+        "dockerfile"
+      ],
       "groupName": "docker"
     },
     {
       "description": "Group Python dependencies",
-      "matchManagers": ["pep621"],
+      "matchManagers": [
+        "pep621"
+      ],
       "groupName": "python-dependencies"
     },
     {
       "description": "Group mise tool updates",
-      "matchManagers": ["mise"],
+      "matchManagers": [
+        "mise"
+      ],
       "groupName": "mise-tools"
     },
     {


### PR DESCRIPTION
## Summary
- Removed the `registryUrls` packageRule for DHI (dhi.io) images
- Verified that Renovate can detect DHI updates with only `hostRules` configuration

The `registryUrls` packageRule was originally needed to prevent Renovate from interpreting `dhi.io/python` as `owner/image` format on Docker Hub. However, testing confirmed that current Renovate (v42+) correctly recognizes `dhi.io` as a registry when `hostRules` specifies `matchHost: "dhi.io"` with `hostType: "docker"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)