### PR TITLE
ci: add auto-approve workflow for Renovate PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,15 @@
+name: Auto approve
+
+on: pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    if: github.event.pull_request.user.login == 'enechange-renovate[bot]'
+    steps:
+      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
+        with:
+          review-message: "Auto approved automated PR"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically approve PRs created by enechange-renovate bot
- Uses `github.event.pull_request.user.login` for secure bot detection (recommended by zizmor to prevent actor spoofing)
- Uses hmarr/auto-approve-action v4 with pinned commit hash

🤖 Generated with [Claude Code](https://claude.ai/code)