### PR TITLE
ci: add release.yml for categorized release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
## Summary

- Add `.github/release.yml` to configure auto-generated release notes
- Separate dependency updates (Renovate PRs) from features for better readability

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

🤖 Generated with [Claude Code](https://claude.ai/code)