### PR TITLE
fix: use >= constraint for pillow override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,5 +68,5 @@ show_missing = true
 
 [tool.uv]
 override-dependencies = [
-    "pillow==12.0.0",  # Override strands-agents-tools constraint
+    "pillow>=12.0.0",  # Override strands-agents-tools upper bound (<12.0.0)
 ]


### PR DESCRIPTION
## Summary

- Change pillow override from `==12.0.0` to `>=12.0.0`
- Allows Renovate to update pillow in dependencies without conflicts
- Resolves version mismatch between dependencies (`pillow==12.1.0`) and override

🤖 Generated with [Claude Code](https://claude.ai/code)