### PR TITLE
feat: add PROMPT_CACHING_TTL environment variable

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -22,6 +22,7 @@ from app.env import (
     LITELLM_TIMEOUT_SECONDS,
     PDF_FILE_ACCESS_ENABLED,
     PROMPT_CACHING_ENABLED,
+    PROMPT_CACHING_TTL,
     REDACT_CREDIT_CARD_PATTERN,
     REDACT_EMAIL_PATTERN,
     REDACT_PHONE_PATTERN,
@@ -269,6 +270,7 @@ def build_messages(
         bot_user_id=context.bot_user_id,
         translate_markdown=TRANSLATE_MARKDOWN,
         prompt_caching_enabled=PROMPT_CACHING_ENABLED,
+        prompt_caching_ttl=PROMPT_CACHING_TTL,
     )
     replies = get_replies(
         client=client,
@@ -285,6 +287,7 @@ def build_messages(
     maybe_set_cache_points(
         messages=messages,
         prompt_caching_enabled=PROMPT_CACHING_ENABLED,
+        prompt_caching_ttl=PROMPT_CACHING_TTL,
     )
     return messages
 

--- a/app/env.py
+++ b/app/env.py
@@ -75,6 +75,7 @@ IMAGE_FILE_ACCESS_ENABLED = (
 PDF_FILE_ACCESS_ENABLED = os.environ.get("PDF_FILE_ACCESS_ENABLED", "false") == "true"
 
 PROMPT_CACHING_ENABLED = os.environ.get("PROMPT_CACHING_ENABLED", "false") == "true"
+PROMPT_CACHING_TTL = os.environ.get("PROMPT_CACHING_TTL")
 
 # Redaction patterns
 #

--- a/docs/features/prompt-caching.md
+++ b/docs/features/prompt-caching.md
@@ -19,6 +19,24 @@ When enabled, cache breakpoints will automatically be added to **the two most re
 
 Currently, this feature is only supported by [models supported by LiteLLM for prompt caching](https://docs.litellm.ai/docs/completion/prompt_caching), such as **Anthropic Claude and Amazon Bedrock models** (e.g., Claude, Amazon Nova).
 
+## Cache TTL
+
+For models that support custom cache TTL, you can specify it via `PROMPT_CACHING_TTL`:
+
+```sh
+PROMPT_CACHING_ENABLED=true
+PROMPT_CACHING_TTL=1h
+```
+
+When set, the TTL value is added to `cache_control`:
+
+```json
+"cache_control": {
+    "type": "ephemeral",
+    "ttl": "1h"
+}
+```
+
 ## Checking cache usage
 
 If you want to check whether prompt caching was used, look at the `cache_read_input_tokens` field in the model response.

--- a/tests/message_logic_test.py
+++ b/tests/message_logic_test.py
@@ -83,13 +83,14 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
 
 
 @pytest.mark.parametrize(
-    "template, bot_user_id, translate_markdown, prompt_caching_enabled, expected",
+    "template, bot_user_id, translate_markdown, prompt_caching_enabled, prompt_caching_ttl, expected",
     [
         (
             "Hello, {bot_user_id}",
             "U12345",
             False,
             False,
+            None,
             {"role": "system", "content": [{"type": "text", "text": "Hello, U12345"}]},
         ),
         (
@@ -97,6 +98,7 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
             "U12345",
             True,
             False,
+            None,
             {
                 "role": "system",
                 "content": [{"type": "text", "text": "**Hello**, U12345!"}],
@@ -107,6 +109,7 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
             "U67890",
             True,
             True,
+            None,
             {
                 "role": "system",
                 "content": [
@@ -123,6 +126,7 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
             None,
             False,
             True,
+            None,
             {
                 "role": "system",
                 "content": [
@@ -139,6 +143,7 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
             "U00000",
             True,
             False,
+            None,
             {
                 "role": "system",
                 "content": [
@@ -149,13 +154,39 @@ def test_filter_replies_after_last_marker(replies, bot_user_id, marker_text, exp
                 ],
             },
         ),
+        (
+            "Hello, {bot_user_id}",
+            "U12345",
+            False,
+            True,
+            "1h",
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello, U12345",
+                        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                    }
+                ],
+            },
+        ),
     ],
 )
 def test_build_system_message(
-    template, bot_user_id, translate_markdown, prompt_caching_enabled, expected
+    template,
+    bot_user_id,
+    translate_markdown,
+    prompt_caching_enabled,
+    prompt_caching_ttl,
+    expected,
 ):
     result = build_system_message(
-        template, bot_user_id, translate_markdown, prompt_caching_enabled
+        template,
+        bot_user_id,
+        translate_markdown,
+        prompt_caching_enabled,
+        prompt_caching_ttl,
     )
 
     assert result == expected
@@ -471,10 +502,11 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
 
 
 @pytest.mark.parametrize(
-    "prompt_caching_enabled, input_messages, expected_messages",
+    "prompt_caching_enabled, prompt_caching_ttl, input_messages, expected_messages",
     [
         (
             False,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "a"}]},
                 {"role": "user", "content": [{"type": "text", "text": "b"}]},
@@ -488,6 +520,7 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
         ),
         (
             True,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "a"}]},
             ],
@@ -497,6 +530,7 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
         ),
         (
             True,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "a"}]},
                 {"role": "user", "content": [{"type": "text", "text": "b"}]},
@@ -526,6 +560,7 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
         ),
         (
             True,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "a"}]},
                 {"role": "user", "content": [{"type": "text", "text": "b"}]},
@@ -557,6 +592,7 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
         ),
         (
             True,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "x"}]},
                 {"role": "assistant", "content": "hi"},
@@ -588,6 +624,7 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
         ),
         (
             True,
+            None,
             [
                 {"role": "user", "content": [{"type": "text", "text": "a"}]},
                 {"role": "assistant", "content": "ignored"},
@@ -619,12 +656,42 @@ def test_build_slack_user_prefixed_text(reply, text, expected):
                 },
             ],
         ),
+        (
+            True,
+            "1h",
+            [
+                {"role": "user", "content": [{"type": "text", "text": "a"}]},
+                {"role": "user", "content": [{"type": "text", "text": "b"}]},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "a",
+                            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "b",
+                            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                        }
+                    ],
+                },
+            ],
+        ),
     ],
 )
 def test_maybe_set_cache_points(
-    prompt_caching_enabled, input_messages, expected_messages
+    prompt_caching_enabled, prompt_caching_ttl, input_messages, expected_messages
 ):
-    maybe_set_cache_points(input_messages, prompt_caching_enabled)
+    maybe_set_cache_points(input_messages, prompt_caching_enabled, prompt_caching_ttl)
 
     assert input_messages == expected_messages
 


### PR DESCRIPTION
## Summary

- Add `PROMPT_CACHING_TTL` environment variable to specify cache TTL for prompt caching
- When set, the TTL value is added to `cache_control` alongside the existing ephemeral type
- Supports models that allow custom cache TTL (e.g., `1h` for 1-hour cache)

🤖 Generated with [Claude Code](https://claude.ai/code)