### PR TITLE
fix: add resourceOauth2ReturnUrl to OAuth polling request

### DIFF
--- a/app/mcp/agentcore_service.py
+++ b/app/mcp/agentcore_service.py
@@ -225,6 +225,7 @@ async def initiate_oauth_flow_with_callback(
             oauth2Flow="USER_FEDERATION",
             workloadIdentityToken=identity_token,
             customState=agentcore_user_id_without_last8,
+            resourceOauth2ReturnUrl=callback_url,
         ).get("accessToken", None),
         user_id=user_id,
         server_name=server_name,


### PR DESCRIPTION
## Summary
- OAuth token polling requests now include `resourceOauth2ReturnUrl` parameter
- This is required by the AWS Bedrock AgentCore API for USER_FEDERATION flows
- Without this parameter, the API returns: "You must provide a ResourceOauth2ReturnUrl to proceed with this flow"

## Background
The custom `CancellableTokenPoller` was missing the `resourceOauth2ReturnUrl` parameter in its polling function. While the initial request via SDK's `get_token` included this parameter, the polling requests did not. AWS has since enforced this parameter for all requests in the OAuth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)