### PR TITLE
fix: use GitHub tags for Python version checks in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,20 @@
   "extends": [
     "config:best-practices"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.mise\\.toml$"
+      ],
+      "matchStrings": [
+        "python\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "python/cpython",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
   "labels": [
     "dependencies"
   ],
@@ -36,6 +50,16 @@
         "pep621"
       ],
       "groupName": "python-dependencies"
+    },
+    {
+      "description": "Disable default mise Python detection to avoid python.org API rate limiting",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
+      "enabled": false
     },
     {
       "description": "Group mise tool updates",


### PR DESCRIPTION
## Summary
- Replace python.org API datasource with GitHub tags (`python/cpython`) for Python version detection in `.mise.toml`
- The python.org API frequently returns 429 (rate limit) errors, causing Renovate to abort entirely with `external-host-error` and skip all dependency updates
- Add a `customManagers` regex rule to extract Python version from `.mise.toml` using `github-tags` datasource, and disable the default `mise` manager's Python detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)