### PR TITLE
fix: prevent Renovate abort on python.org 429 rate limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,11 +3,17 @@
   "extends": [
     "config:best-practices"
   ],
+  "hostRules": [
+    {
+      "hostType": "python-version",
+      "abortIgnoreStatusCodes": [429]
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.mise\\.toml$"
+      "managerFilePatterns": [
+        "/^\\.mise\\.toml$/"
       ],
       "matchStrings": [
         "python\\s*=\\s*\"(?<currentValue>[^\"]+)\""


### PR DESCRIPTION
## Summary
- Add `hostRules` with `abortIgnoreStatusCodes: [429]` for `python-version` hostType to prevent Renovate from aborting the entire run when python.org returns a rate limit error
- The previous fix (`enabled: false` in packageRules) only prevented PR creation but did not stop the extraction/lookup phase from querying python.org and triggering the abort
- Fix `fileMatch` -> `managerFilePatterns` migration warning in customManagers

🤖 Generated with [Claude Code](https://claude.com/claude-code)