### PR TITLE
fix: ignore python dep in Renovate to avoid python.org rate limiting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,19 +3,8 @@
   "extends": [
     "config:best-practices"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^\\.mise\\.toml$"
-      ],
-      "matchStrings": [
-        "python\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "depNameTemplate": "python/cpython",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    }
+  "ignoreDeps": [
+    "python"
   ],
   "labels": [
     "dependencies"
@@ -50,16 +39,6 @@
         "pep621"
       ],
       "groupName": "python-dependencies"
-    },
-    {
-      "description": "Disable default mise Python detection to avoid python.org API rate limiting",
-      "matchManagers": [
-        "mise"
-      ],
-      "matchPackageNames": [
-        "python"
-      ],
-      "enabled": false
     },
     {
       "description": "Group mise tool updates",


### PR DESCRIPTION
## Summary
- Replace `customManagers` / `packageRules` workarounds with `ignoreDeps: ["python"]` to prevent python.org API lookups entirely
- The python.org API returns 429 rate limit errors, causing Renovate to abort all dependency updates
- `.mise.toml`'s Python version follows the Docker image (`dhi.io/python`) and is managed manually, so Renovate does not need to check it
- Docker image updates are unaffected as the dep name is `dhi.io/python`, not `python`

🤖 Generated with [Claude Code](https://claude.com/claude-code)