### PR TITLE
feat: sync .mise.toml Python version with Docker image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,20 @@
   "ignoreDeps": [
     "python"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.mise\\.toml$/"
+      ],
+      "matchStrings": [
+        "python\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "dhi.io/python",
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)"
+    }
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary
- Add a custom regex manager that tracks `dhi.io/python` Docker image tags to update `.mise.toml`'s Python version
- Uses `extractVersionTemplate` to extract semver (`3.14.3`) from Docker tags (`3.14.3-debian13`)
- Kept as a separate PR from Docker image updates to preserve the causal relationship between changes
- Does not query python.org, avoiding the 429 rate limit issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)