### PR TITLE
feat: add log level option to Renovate workflow dispatch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,6 +6,14 @@ on:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:
+    inputs:
+      log-level:
+        description: 'Log level'
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
 
 permissions:
   contents: read
@@ -38,5 +46,6 @@ jobs:
           configurationFile: .github/renovate.json
           token: ${{ steps.app-token.outputs.token }}
         env:
+          LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary
- Add `log-level` input to `workflow_dispatch` with `info` (default) and `debug` options
- Pass `LOG_LEVEL` env var to the Renovate action
- Defaults to `info` for push and schedule triggers (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)