### PR TITLE
fix: disable Docker digest pinning for .mise.toml Python version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,6 +55,16 @@
       "groupName": "python-dependencies"
     },
     {
+      "description": "Disable Docker digest pinning for .mise.toml Python version",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "dhi.io/python"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Group mise tool updates",
       "matchManagers": [
         "mise"


### PR DESCRIPTION
## Summary
- Add `pinDigests: false` for the `custom.regex` manager's `dhi.io/python` dependency
- The `config:best-practices` preset attempts to pin `.mise.toml`'s Python version with a Docker digest (`sha256:...`), which fails because TOML version strings don't support digests
- This was causing the `renovate/pin-dependencies` branch update failure seen in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)