### PR TITLE
chore: remove unnecessary pillow override dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,3 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
-
-[tool.uv]
-override-dependencies = [
-    "pillow>=12.0.0",  # Override strands-agents-tools upper bound (<12.0.0)
-]

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[manifest]
-overrides = [{ name = "pillow", specifier = ">=12.0.0" }]
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

- Remove `pillow>=12.0.0` override from `[tool.uv]` section
- strands-agents-tools 0.2.21 now requires `pillow>=12.1.1,<13.0.0`, which is compatible with current pillow version (12.1.1)
- Override is no longer necessary and was verified by running `uv lock` and `validate.sh` successfully

🤖 Generated with [Claude Code](https://claude.ai/code)