### PR TITLE
chore: schedule lockFileMaintenance to weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,7 +29,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "at any time"
+      "before 4am on monday"
     ]
   },
   "packageRules": [


### PR DESCRIPTION
## Summary

- Change lock file maintenance schedule from "at any time" to "before 4am on monday" (weekly)
- Prevents ping-pong loops caused by uv version differences between Renovate and CI environments

🤖 Generated with [Claude Code](https://claude.ai/code)