### PR TITLE
chore: sync uv version between mise and Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,9 @@
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)"
     }
   ],
+  "constraints": {
+    "uv": "0.10.6"
+  },
   "labels": [
     "dependencies"
   ],
@@ -29,7 +32,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "before 4am on monday"
+      "at any time"
     ]
   },
   "packageRules": [


### PR DESCRIPTION
## Summary
- Add `constraints.uv` to `renovate.json` to pin the uv version Renovate uses for lock file operations
- Revert lockFileMaintenance schedule back to "at any time"

## Background
Renovate's lock file maintenance has been creating repeated PRs. One possible cause is a uv version mismatch between CI (pinned in `.mise.toml`) and Renovate (unpinned). This change pins Renovate's uv version via constraints to help isolate the cause, and reverts the schedule restriction that was added as a temporary workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)