### PR TITLE
feat: auto-update Renovate uv constraints via regex manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,18 @@
       "depNameTemplate": "dhi.io/python",
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/renovate\\.json$/"
+      ],
+      "matchStrings": [
+        "\"constraints\":\\s*\\{[^}]*\"uv\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
     }
   ],
   "constraints": {
@@ -68,11 +80,25 @@
       "pinDigests": false
     },
     {
-      "description": "Group mise tool updates",
+      "description": "Group mise tool updates (except uv)",
       "matchManagers": [
         "mise"
       ],
+      "excludePackageNames": [
+        "uv"
+      ],
       "groupName": "mise-tools"
+    },
+    {
+      "description": "Group uv updates (mise and constraints)",
+      "matchPackageNames": [
+        "uv",
+        "astral-sh/uv"
+      ],
+      "excludeManagers": [
+        "dockerfile"
+      ],
+      "groupName": "uv"
     },
     {
       "description": "Automerge minor, patch, digest, and lockFileMaintenance updates",


### PR DESCRIPTION
## Summary
- Add a custom regex manager to detect and update the uv version in `renovate.json` constraints
- Group mise `uv` and constraints `astral-sh/uv` updates together in a single PR
- Exclude Docker uv image from the uv group

## Background
After pinning Renovate's uv version via `constraints.uv` in #915, this change ensures the constraint version stays in sync with `.mise.toml` automatically when Renovate detects a new uv release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)