### PR TITLE
fix: replace invalid excludeManagers with matchManagers in uv group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -91,12 +91,13 @@
     },
     {
       "description": "Group uv updates (mise and constraints)",
+      "matchManagers": [
+        "mise",
+        "custom.regex"
+      ],
       "matchPackageNames": [
         "uv",
         "astral-sh/uv"
-      ],
-      "excludeManagers": [
-        "dockerfile"
       ],
       "groupName": "uv"
     },


### PR DESCRIPTION
## Summary
- Replace invalid `excludeManagers` option with `matchManagers: ["mise", "custom.regex"]` in the uv grouping rule
- Fixes config validation error introduced in #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)