### PR TITLE
chore: group Python runtime version updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,7 +60,21 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "excludePackageNames": [
+        "dhi.io/python"
+      ],
       "groupName": "docker"
+    },
+    {
+      "description": "Group Python runtime version updates",
+      "matchManagers": [
+        "dockerfile",
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "dhi.io/python"
+      ],
+      "groupName": "python"
     },
     {
       "description": "Group Python dependencies",


### PR DESCRIPTION
## Summary

- Add a dedicated "python" group in Renovate configuration to combine `dhi.io/python` updates from both Dockerfile and `.mise.toml` into a single PR
- Exclude `dhi.io/python` from the existing "docker" group to prevent duplicate grouping
- Ensure Python runtime version updates are managed together across different files

🤖 Generated with [Claude Code](https://claude.ai/code)