### PR TITLE
chore: group uv updates across Dockerfile, mise, and constraints

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,16 +56,6 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group Docker image updates",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "groupName": "docker",
-      "matchPackageNames": [
-        "!dhi.io/python"
-      ]
-    },
-    {
       "description": "Group Python runtime version updates",
       "matchManagers": [
         "dockerfile",
@@ -104,12 +94,14 @@
       ]
     },
     {
-      "description": "Group uv updates (mise and constraints)",
+      "description": "Group uv updates (Dockerfile, mise, and constraints)",
       "matchManagers": [
+        "dockerfile",
         "mise",
         "custom.regex"
       ],
       "matchPackageNames": [
+        "ghcr.io/astral-sh/uv",
         "uv",
         "astral-sh/uv"
       ],


### PR DESCRIPTION
## Summary

- Add Dockerfile manager and `ghcr.io/astral-sh/uv` to the uv group, consolidating all uv version updates into a single PR
- Remove redundant docker group as all Dockerfile images now have specific groups (python and uv)
- Ensures consistent uv versioning across Dockerfile, `.mise.toml`, and `renovate.json` constraints

🤖 Generated with [Claude Code](https://claude.ai/code)