### PR TITLE
ci: remove push trigger from Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,6 @@
 name: Renovate
 
 on:
-  push:
-    branches: [main]
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Remove push trigger from Renovate workflow to prevent ping-pong behavior
- Renovate was creating lockFileMaintenance PRs that get auto-merged, which immediately triggered another Renovate run, creating conflicting PRs that reverse the changes
- Schedule-based execution (hourly) is sufficient for dependency updates

🤖 Generated with [Claude Code](https://claude.ai/code)