### PR TITLE
ci: limit lockFileMaintenance to daily schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "at any time"
+      "after 11pm every day"
     ]
   },
   "packageRules": [

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,8 @@
 name: Renovate
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Restrict lockFileMaintenance to run only after 11pm UTC (JST 8am) instead of "at any time"
- Prevents hourly ping-pong behavior where Renovate creates conflicting lockfile PRs
- Restore push trigger for regular dependency updates, which only run outside lockFileMaintenance schedule

🤖 Generated with [Claude Code](https://claude.ai/code)