### PR TITLE
fix: suppress litellm's Pydantic serialization warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import os
 import re
 import signal
 import sys
+import warnings
 from types import FrameType
 
 from slack_bolt import Ack, App
@@ -41,6 +42,10 @@ def main() -> None:
         None
     """
     logging.basicConfig(level=SLACK_APP_LOG_LEVEL)
+
+    # Suppress litellm's PydanticSerializationUnexpectedValue warnings
+    # https://github.com/BerriAI/litellm/issues/17631
+    warnings.filterwarnings("ignore", message="Pydantic serializer warnings")
 
     app = create_bolt_app(os.environ["SLACK_BOT_TOKEN"], USE_SLACK_LOCALE)
     append_rate_limit_retry_handler(app.client.retry_handlers, 2)


### PR DESCRIPTION
## Summary
- Suppress `PydanticSerializationUnexpectedValue` warnings emitted by litellm when serializing `ResponseAPIUsage`
- This is a known litellm issue (https://github.com/BerriAI/litellm/issues/17631) where Pydantic model definitions are incomplete for newer OpenAI response fields
- The warnings are cosmetic only and do not affect functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)