### PR TITLE
fix: allow parallel tool calls for Bedrock Claude 4.5+

### DIFF
--- a/app/litellm_service.py
+++ b/app/litellm_service.py
@@ -124,7 +124,6 @@ def call_litellm_completion(
 
     if tools is not None:
         kwargs["tools"] = tools
-        kwargs["parallel_tool_calls"] = False
 
     additional_kwargs: dict[str, list[str]] = {}
     if LITELLM_DROP_PARAMS is not None:


### PR DESCRIPTION
## Summary
- Remove explicit `parallel_tool_calls=False` setting that triggers a litellm bug ([BerriAI/litellm#22637](https://github.com/BerriAI/litellm/issues/22637)) on Bedrock Claude 4.5+ models
- Parallel tool calls have been verified to work correctly with Bedrock Claude Opus 4.5, GPT, and Gemini 3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)