### PR TITLE
Fix typos in translation prompt

### DIFF
--- a/app/translation_logic.py
+++ b/app/translation_logic.py
@@ -88,10 +88,10 @@ def build_translation_messages(lang: str, original: str) -> list[dict[str, str]]
     """
     system_text = (
         "You're the AI model that primarily focuses on the quality of language translation. "
-        "You always respond with the only the translated text in a format suitable for Slack user "
+        "You always respond with only the translated text in a format suitable for Slack user "
         "interface. Slack's emoji (e.g., :hourglass_flowing_sand:) and mention parts must be kept "
         "as-is. You don't change the meaning of sentences when translating them into a different "
-        "language. When the given text is a single verb/noun, its translated text must be a norm/"
+        "language. When the given text is a single verb/noun, its translated text must be a noun/"
         "verb form too. When the given text is in markdown format, the format must be kept as much "
         "as possible."
     )

--- a/tests/translation_logic_test.py
+++ b/tests/translation_logic_test.py
@@ -100,11 +100,11 @@ def test_set_cached_translation(lang, original, translated, expected_cache):
                     "role": "system",
                     "content": (
                         "You're the AI model that primarily focuses on the quality of language translation. "
-                        "You always respond with the only the translated text in a format suitable for Slack "
+                        "You always respond with only the translated text in a format suitable for Slack "
                         "user interface. Slack's emoji (e.g., :hourglass_flowing_sand:) and mention parts must "
                         "be kept as-is. You don't change the meaning of sentences when translating them into a "
                         "different language. When the given text is a single verb/noun, its translated text "
-                        "must be a norm/verb form too. When the given text is in markdown format, the format "
+                        "must be a noun/verb form too. When the given text is in markdown format, the format "
                         "must be kept as much as possible."
                     ),
                 },
@@ -127,11 +127,11 @@ def test_set_cached_translation(lang, original, translated, expected_cache):
                     "role": "system",
                     "content": (
                         "You're the AI model that primarily focuses on the quality of language translation. "
-                        "You always respond with the only the translated text in a format suitable for Slack "
+                        "You always respond with only the translated text in a format suitable for Slack "
                         "user interface. Slack's emoji (e.g., :hourglass_flowing_sand:) and mention parts must "
                         "be kept as-is. You don't change the meaning of sentences when translating them into a "
                         "different language. When the given text is a single verb/noun, its translated text "
-                        "must be a norm/verb form too. When the given text is in markdown format, the format "
+                        "must be a noun/verb form too. When the given text is in markdown format, the format "
                         "must be kept as much as possible."
                     ),
                 },


### PR DESCRIPTION
## Summary
- Fix "the only the" → "only the" (redundant article)
- Fix "norm/verb" → "noun/verb" (typo affecting translation instructions)

Ported from seratch/ChatGPT-in-Slack#141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)