### PR TITLE
fix: harden Renovate config against supply chain attacks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,12 +41,7 @@
   "rebaseWhen": "conflicted",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "after 11pm"
-    ]
-  },
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Group GitHub Actions updates",
@@ -108,12 +103,11 @@
       "groupName": "uv"
     },
     {
-      "description": "Automerge minor, patch, digest, and lockFileMaintenance updates",
+      "description": "Automerge minor, patch, and digest updates",
       "matchUpdateTypes": [
         "minor",
         "patch",
-        "digest",
-        "lockFileMaintenance"
+        "digest"
       ],
       "automerge": true
     }


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "3 days"` to delay dependency updates, reducing exposure to compromised packages
- Disable `lockFileMaintenance` which bypassed the cooldown for transitive dependencies
- Remove `lockFileMaintenance` from automerge rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)