### PR TITLE
feat: skip minimumReleaseAge for Docker Hardened Images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,7 +59,8 @@
       "matchPackageNames": [
         "dhi.io/python"
       ],
-      "groupName": "python"
+      "groupName": "python",
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Group Python dependencies",


### PR DESCRIPTION
## Summary

- Skip 3-day release age delay for Docker Hardened Images (dhi.io/python)
- dhi.io images are security-hardened and trusted, so supply chain protection delay is unnecessary

🤖 Generated with [Claude Code](https://claude.ai/code)