### PR TITLE
chore: temporarily disable trivy-action in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -111,6 +111,13 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Temporarily disable trivy-action due to supply chain attack aftermath",
+      "matchPackageNames": [
+        "aquasecurity/trivy-action"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Temporarily disable Renovate updates for `aquasecurity/trivy-action` due to GitHub tag lookup failures following the March 2026 supply chain attack
- The current pinned version (v0.35.0 at SHA `57a97c7e...`) is safe and unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)