### PR TITLE
feat: enable retry-on-snapshot-warnings in dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,5 +20,6 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           comment-summary-in-pr: always
+          retry-on-snapshot-warnings: true
           license-check: false
           show-openssf-scorecard: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Enable `retry-on-snapshot-warnings: true` in dependency-review-action
- Addresses GitHub's snapshot propagation delays that cause "No snapshots were found for the head SHA" warnings

🤖 Generated with [Claude Code](https://claude.ai/code)