### PR TITLE
fix: add statuses permission for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,6 +40,7 @@ jobs:
           permission-pull-requests: write
           permission-vulnerability-alerts: read
           permission-workflows: write
+          permission-statuses: write
 
       - name: Run Renovate
         uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6


### PR DESCRIPTION
## Summary

- Add `permission-statuses: write` to the GitHub App token generation
- Fixes Renovate aborting with "repository-changed" due to 403 error when setting commit statuses

🤖 Generated with [Claude Code](https://claude.ai/code)