### PR TITLE
fix: add checks permission for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,6 +41,7 @@ jobs:
           permission-vulnerability-alerts: read
           permission-workflows: write
           permission-statuses: write
+          permission-checks: write
 
       - name: Run Renovate
         uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6


### PR DESCRIPTION
## Summary

- Add `permission-checks: write` to match the GitHub App configuration
- Ensures all App permissions are properly requested in the token

🤖 Generated with [Claude Code](https://claude.ai/code)