### PR TITLE
chore: add migration notice and disable scheduled workflows

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,8 +3,8 @@ name: Renovate
 on:
   push:
     branches: [main]
-  schedule:
-    - cron: '0 * * * *'
+  # schedule:
+  #   - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       log-level:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,8 +3,8 @@ name: Trivy
 on:
   push:
     branches: [main]
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+> [!IMPORTANT]
+> **This repository is no longer actively maintained.**
+>
+> Development continues at [iwamot/collmbo](https://github.com/iwamot/collmbo).
+>
+> For v11.0.0 and later versions:
+>
+> ```sh
+> docker pull ghcr.io/iwamot/collmbo:latest
+> ```
+
+---
+
 # Collmbo
 
 [![CI](https://github.com/enechange/collmbo/actions/workflows/ci.yml/badge.svg)](https://github.com/enechange/collmbo/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

- Add migration notice to README pointing users to [iwamot/collmbo](https://github.com/iwamot/collmbo)
- Disable scheduled runs for Renovate and Trivy workflows

🤖 Generated with [Claude Code](https://claude.ai/code)